### PR TITLE
Synonyms should have an `acceptedConceptName` field 

### DIFF
--- a/grails-app/services/au/org/ala/bie/SearchService.groovy
+++ b/grails-app/services/au/org/ala/bie/SearchService.groovy
@@ -700,11 +700,10 @@ class SearchService {
 
                 if(it.acceptedConceptID){
                     doc.put("acceptedConceptID", it.acceptedConceptID)
+                    if (it.acceptedConceptName)
+                        doc.put("acceptedConceptName", it.acceptedConceptName)
                     doc.put("guid", it.acceptedConceptID)
-                }
-
-                if(it.synonymDescription_s == "synonym"){
-                    doc.put("acceptedConceptName", it.acceptedConceptName)
+                    doc.put("linkIdentifier", null)  // Otherwise points to the synonym
                 }
 
                 if(it.image){


### PR DESCRIPTION
See https://github.com/AtlasOfLivingAustralia/bie-index/issues/64