### PR TITLE
Fix for issue-139.

### DIFF
--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -50,7 +50,9 @@ wordPress {
 }
 speciesList.url = "http://lists.ala.org.au/ws/speciesListItems/"
 speciesList.params = "?includeKVP=true"
-autoComplete.languages='en,en-AU,en-CA,en-GB,en-US'
+// Acceptable vernacular names to appear in autocomplete
+//autoComplete.languages = 'en,en-AU,en-CA,en-GB,en-US'
+autoComplete.languages = ''
 // Location of conservation lists
 conservationListsUrl = this.class.getResource("/default-conservation-lists.json").toString()
 // Location of vernacular name lists (null for default)

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -50,6 +50,7 @@ wordPress {
 }
 speciesList.url = "http://lists.ala.org.au/ws/speciesListItems/"
 speciesList.params = "?includeKVP=true"
+autoComplete.languages='en,en-AU,en-CA,en-GB,en-US'
 // Location of conservation lists
 conservationListsUrl = this.class.getResource("/default-conservation-lists.json").toString()
 // Location of vernacular name lists (null for default)
@@ -194,6 +195,6 @@ log4j = {
             'grails.app.taglib.org.grails.plugin.resource',
             'grails.app.resourceMappers.org.grails.plugin.resource'
 
-    debug   "grails.app",
+    info    "grails.app",
             "au.org.ala"
 }

--- a/grails-app/services/au/org/ala/bie/ImportService.groovy
+++ b/grails-app/services/au/org/ala/bie/ImportService.groovy
@@ -99,6 +99,7 @@ class ImportService {
 
     def importAll() {
         try {
+            // Do this first so that source datasets can be retrieved
             importCollectory()
         } catch (Exception e) {
             log("Problem loading collectory: " + e.getMessage())
@@ -147,6 +148,16 @@ class ImportService {
             buildLinkIdentifiers(false)
         } catch (Exception e) {
             log("Problem building link identifiers: " + e.getMessage())
+        }
+        try {
+            loadImages(false)
+        } catch (Exception e) {
+            log("Problem loading images: " + e.getMessage())
+        }
+        try {
+            importOccurrenceData()
+        } catch (Exception e) {
+            log("Problem importing occurrence data: " + e.getMessage())
         }
     }
 
@@ -1643,6 +1654,7 @@ class ImportService {
         def prevCursor = ""
         def cursor = "*"
         def startTime, endTime
+        Set autoLanguages = grailsApplication.config.autoComplete.languages ? grailsApplication.config.autoComplete.languages.split(',') as Set : null
 
         js.setType(JsonParserType.INDEX_OVERLAY)
         log("Getting species groups")
@@ -1705,7 +1717,7 @@ class ImportService {
                 log "1. Paging over ${total} docs - page ${(processed + 1)}"
 
                 docs.each { doc ->
-                    denormaliseEntry(doc, [:], [], [], buffer, bufferLimit, pageSize, online, js, speciesGroupMapper)
+                    denormaliseEntry(doc, [:], [], [], buffer, bufferLimit, pageSize, online, js, speciesGroupMapper, autoLanguages)
                 }
                 processed++
                 if (!buffer.isEmpty())
@@ -1738,7 +1750,7 @@ class ImportService {
                 log "2. Paging over ${total} docs - page ${(processed + 1)}"
 
                 docs.each { doc ->
-                    denormaliseEntry(doc, [:], [], [], buffer, bufferLimit, pageSize, online, js, speciesGroupMapper)
+                    denormaliseEntry(doc, [:], [], [], buffer, bufferLimit, pageSize, online, js, speciesGroupMapper, autoLanguages)
                 }
                 processed++
                 if (!buffer.isEmpty())
@@ -1804,7 +1816,7 @@ class ImportService {
         log("Finished taxon denormalisaion. Duration: ${(new SimpleDateFormat("mm:ss:SSS")).format(new Date(endTime - startTime))}")
     }
 
-    private denormaliseEntry(doc, Map trace, List speciesGroups, List speciesSubGroups, List buffer, int bufferLimit, int pageSize, boolean online, JsonSlurper js, Map speciesGroupMapping) {
+    private denormaliseEntry(doc, Map trace, List speciesGroups, List speciesSubGroups, List buffer, int bufferLimit, int pageSize, boolean online, JsonSlurper js, Map speciesGroupMapping, Set autoLanguages) {
         def currentDistribution = (doc['distribution'] ?: []) as Set
         if (doc.denormalised_b)
             return currentDistribution
@@ -1843,8 +1855,9 @@ class ImportService {
                 n2.priority - n1.priority
             }
 
-            //only index english names
-            commonNames = commonNames.findAll { it.language == 'en' }
+            //only index valid languages
+            if (autoLanguages)
+                commonNames = commonNames.findAll { autoLanguages.contains(it.language) }
 
             if(commonNames) {
                 update["commonName"] = [set: commonNames.collect { it.name }]
@@ -1868,7 +1881,7 @@ class ImportService {
             int total = json.response.numFound
             def docs = json.response.docs
             docs.each { child ->
-                distribution.addAll(denormaliseEntry(child, trace, speciesGroups, speciesSubGroups, buffer, bufferLimit, pageSize, online, js, speciesGroupMapping))
+                distribution.addAll(denormaliseEntry(child, trace, speciesGroups, speciesSubGroups, buffer, bufferLimit, pageSize, online, js, speciesGroupMapping, autoLanguages))
             }
             prevCursor = cursor
             cursor = json.nextCursorMark

--- a/grails-app/services/au/org/ala/bie/ImportService.groovy
+++ b/grails-app/services/au/org/ala/bie/ImportService.groovy
@@ -1663,11 +1663,15 @@ class ImportService {
         log("Clearing existing denormalisations")
         try {
             startTime = System.currentTimeMillis()
+
+            def solrServerUrl = baseUrl + "/select?wt=json&q=denormalised_b:true&rows=1"
+            def queryResponse = solrServerUrl.toURL().getText("UTF-8")
+            def json = js.parseText(queryResponse)
+            int total = json.response.numFound
             while (prevCursor != cursor) {
-                def solrServerUrl = baseUrl + "/select?wt=json&q=denormalised_b:true&cursorMark=${cursor}&sort=id+asc&rows=${pageSize}"
-                def queryResponse = solrServerUrl.toURL().getText("UTF-8")
-                def json = js.parseText(queryResponse)
-                int total = json.response.numFound
+                solrServerUrl = baseUrl + "/select?wt=json&q=denormalised_b:true&cursorMark=${cursor}&sort=id+asc&rows=${pageSize}"
+                queryResponse = solrServerUrl.toURL().getText("UTF-8")
+                json = js.parseText(queryResponse)
                 def docs = json.response.docs
                 def buffer = []
 
@@ -1705,13 +1709,16 @@ class ImportService {
             processed = 0
             prevCursor = ""
             cursor = "*"
+            def typeQuery = "idxtype:\"" + IndexDocType.TAXON.name() + "\"+AND+-acceptedConceptID:*+AND+-parentGuid:*"
+            def solrServerUrl = baseUrl + "/select?wt=json&q=${typeQuery}&rows=1"
+            def queryResponse = solrServerUrl.toURL().getText("UTF-8")
+            def json = js.parseText(queryResponse)
+            int total = json.response.numFound
             while (prevCursor != cursor) {
                 //startTime = System.currentTimeMillis()
-                def typeQuery = "idxtype:\"" + IndexDocType.TAXON.name() + "\"+AND+-acceptedConceptID:*+AND+-parentGuid:*"
-                def solrServerUrl = baseUrl + "/select?wt=json&q=${typeQuery}&cursorMark=${cursor}&sort=id+asc&rows=${pageSize}"
-                def queryResponse = Encoder.encodeUrl(solrServerUrl).toURL().getText("UTF-8")
-                def json = js.parseText(queryResponse)
-                int total = json.response.numFound
+                solrServerUrl = baseUrl + "/select?wt=json&q=${typeQuery}&cursorMark=${cursor}&sort=id+asc&rows=${pageSize}"
+                queryResponse = Encoder.encodeUrl(solrServerUrl).toURL().getText("UTF-8")
+                json = js.parseText(queryResponse)
                 def docs = json.response.docs
                 def buffer = []
                 log "1. Paging over ${total} docs - page ${(processed + 1)}"
@@ -1738,13 +1745,16 @@ class ImportService {
             processed++
             prevCursor = ""
             cursor = "*"
+            def danglingQuery = "idxtype:\"${IndexDocType.TAXON.name()}\"+AND++-acceptedConceptID:*+AND+-denormalised_s:yes"
+            def solrServerUrl = baseUrl + "/select?wt=json&q=${danglingQuery}&rows=1"
+            def queryResponse = Encoder.encodeUrl(solrServerUrl).toURL().getText("UTF-8")
+            def json = js.parseText(queryResponse)
+            int total = json.response.numFound
             while (prevCursor != cursor) {
                 //startTime = System.currentTimeMillis()
-                def danglingQuery = "idxtype:\"${IndexDocType.TAXON.name()}\"+AND++-acceptedConceptID:*+AND+-denormalised_s:yes"
-                def solrServerUrl = baseUrl + "/select?wt=json&q=${danglingQuery}&cursorMark=${cursor}&sort=id+asc&rows=${pageSize}"
-                def queryResponse = Encoder.encodeUrl(solrServerUrl).toURL().getText("UTF-8")
-                def json = js.parseText(queryResponse)
-                int total = json.response.numFound
+                solrServerUrl = baseUrl + "/select?wt=json&q=${danglingQuery}&cursorMark=${cursor}&sort=id+asc&rows=${pageSize}"
+                queryResponse = Encoder.encodeUrl(solrServerUrl).toURL().getText("UTF-8")
+                json = js.parseText(queryResponse)
                 def docs = json.response.docs
                 def buffer = []
                 log "2. Paging over ${total} docs - page ${(processed + 1)}"
@@ -1771,13 +1781,16 @@ class ImportService {
             processed = 0
             prevCursor = ""
             cursor = "*"
+            def synonymQuery = "idxtype:\"${IndexDocType.TAXON.name()}\"+AND+acceptedConceptID:*"
+            def solrServerUrl = baseUrl + "/select?wt=json&q=${synonymQuery}&rows=1"
+            def queryResponse = Encoder.encodeUrl(solrServerUrl).toURL().getText("UTF-8")
+            def json = js.parseText(queryResponse)
+            int total = json.response.numFound
             while (prevCursor != cursor) {
                 //startTime = System.currentTimeMillis()
-                def synonymQuery = "idxtype:\"${IndexDocType.TAXON.name()}\"+AND+acceptedConceptID:*"
-                def solrServerUrl = baseUrl + "/select?wt=json&q=${synonymQuery}&cursorMark=${cursor}&sort=id+asc&rows=${pageSize}"
-                def queryResponse = Encoder.encodeUrl(solrServerUrl).toURL().getText("UTF-8")
-                def json = js.parseText(queryResponse)
-                int total = json.response.numFound
+                solrServerUrl = baseUrl + "/select?wt=json&q=${synonymQuery}&cursorMark=${cursor}&sort=id+asc&rows=${pageSize}"
+                queryResponse = Encoder.encodeUrl(solrServerUrl).toURL().getText("UTF-8")
+                json = js.parseText(queryResponse)
                 def docs = json.response.docs
                 def buffer = []
                 log "3. Paging over ${total} docs - page ${(processed + 1)}"
@@ -1878,7 +1891,6 @@ class ImportService {
             def solrServerUrl = baseUrl + "/select?wt=json&q=${parentQuery}&cursorMark=${cursor}&sort=id+asc&rows=${pageSize}"
             def queryResponse = solrServerUrl.toURL().getText("UTF-8")
             def json = js.parseText(queryResponse)
-            int total = json.response.numFound
             def docs = json.response.docs
             docs.each { child ->
                 distribution.addAll(denormaliseEntry(child, trace, speciesGroups, speciesSubGroups, buffer, bufferLimit, pageSize, online, js, speciesGroupMapping, autoLanguages))


### PR DESCRIPTION
Allows configured language filter for common names in main taxon.
The configuration entry autoComplete.languages can contain a comma-separated list of language/language-country codes that can be used to filter vernacular names. If left blank, all vernacular names are included.