### PR TITLE
additionalResultFields included in individual species

### DIFF
--- a/grails-app/services/au/org/ala/bie/SearchService.groovy
+++ b/grails-app/services/au/org/ala/bie/SearchService.groovy
@@ -943,6 +943,18 @@ class SearchService {
             model.taxonConcept["acceptedConceptID"] = taxon.acceptedConceptID
         if (taxon.acceptedConceptName)
             model.taxonConcept["acceptedConceptName"] = taxon.acceptedConceptName
+        
+        if(getAdditionalResultFields()) {
+            def doc = [:]
+            getAdditionalResultFields().each { field ->
+                if (taxon."${field}") {
+                    doc.put(field, taxon."${field}")
+                }
+            }
+
+            model << doc
+        }
+        
         model
     }
 


### PR DESCRIPTION
the config.additionalResultFields were only included in the search results list of species. This ensures they are also incorporated into individual species results as well, so they can be taken up by e.g. bie-plugin