### PR TITLE
Fix to search bq and hl parameters

### DIFF
--- a/grails-app/services/au/org/ala/bie/SearchService.groovy
+++ b/grails-app/services/au/org/ala/bie/SearchService.groovy
@@ -151,9 +151,9 @@ class SearchService {
         // Add query parameters
         query << "defType=${grailsApplication.config.solr.defType}" // Query parser type
         query << "qf=${grailsApplication.config.solr.qf}" // dismax query fields
-        grailsApplication.config.solr.bq.each { query << "bq=${it}" } // dismax boosts
+        query << "${grailsApplication.config.solr.bq}" // dismax boosts
         query << "q.alt=${grailsApplication.config.solr.qAlt}" // if no query specified use this query
-        grailsApplication.config.solr.hl.each { query << "hl=${it}" } // highlighting parameters
+        query << "hl=${grailsApplication.config.solr.hl}" // highlighting parameters
         query << "wt=json"
         query << "facet=${!requestedFacets.isEmpty()}"
         query << "facet.mincount=1"


### PR DESCRIPTION
The existing code takes the example config options (as per https://github.com/AtlasOfLivingAustralia/ala-install/blob/master/ansible/roles/bie-index/templates/bie-index-config.properties) and splits them up into individual letters, which doesn't work. Is it possible to either update the ansible template to reflect the way in which these parameters must now be provided to work as arrays/lists as implied in the original code, or basically revert to the code in this fork? Thanks guys