### PR TITLE
Add provenance field

### DIFF
--- a/doc/nameology/conventions.md
+++ b/doc/nameology/conventions.md
@@ -230,6 +230,7 @@ It can contain the following columns
 | [verbatimNomenclaturalCode](http://ala.org.au/terms/1.0/verbatimNomenclaturalCode) | no | no | The supplied nomenclaural code |
 | [verbatimTaxonomicStatus](http://ala.org.au/terms/1.0/verbatimTaxonomicStatus) | no | no | The supplied taxonomic status |
 | [verbatimNomenclaturalStatus](http://ala.org.au/terms/1.0/verbatimNomenclaturalStatus) | no | no | The supplied nomenclaural status |
+| [provenance](http://purl.org/dc/terms/provenance) | no | no | Information about how a taxon has been processed or modified. Multiple provenance statements are separated by vertical bars  |
 
 
 senior- or self-synonyms are not included in taxon.csv.
@@ -266,7 +267,8 @@ It contains the following columns
 | [isPreferredName](http://rs.gbif.org/terms/1.0/isPreferredName) | input only | Mapped onto the status vocabulary |
 | [organismPart](http://rs.gbif.org/terms/1.0/organismPart) | no | The part of the organism this name applies to (eg tail) |
 | [labels](http://ala.org.au/terms/1.0/labels) | no | Context labels, separated by a vertical bar. See http://localcontexts.org/  |
-| [taxonRemarks](http://rs.tdwg.org/dwc/terms/taxonRemarks) | no | Any additional remarks  |
+| [taxonRemarks](http://rs.tdwg.org/dwc/terms/taxonRemarks) | no | Any additional remarks. Multiple remarks are separated by vertical bars  |
+| [provenance](http://purl.org/dc/terms/provenance) | no | Information about how a name has been processed or modified. Multiple provenance statements are separated by vertical bars  |
 
 Note that a vernacular name, eg. "Blue Gum", can be linked to any number of scientific names.
 
@@ -300,6 +302,7 @@ It contains the following columns
 | [datasetID](http://rs.tdwg.org/dwc/terms/datasetID) | no | The source collectory dataset for this identifier |
 | [source](http://purl.org/dc/terms/source) | no | The linked-data source of the identifier  |
 | [status](http://ala.org.au/terms/1.0/status) | no | The status of the identifier |
+| [provenance](http://purl.org/dc/terms/provenance) | no | Information about how an identifier has been processed or modified. Multiple provenance statements are separated by vertical bars  |
 
 Identifier status gives a hint as to how additional identifiers should be interpreted.
 They use the following vocabulary:

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -166,24 +166,13 @@ priority:
 # SOLR additional params
 solr:
     qf: scientificName^1000+commonName^500+exact_text^200+doc_name^100+text
-    bq:
-      - taxonomicStatus:accepted^2000
-      - rankID:7000^500
-      - rankID:6000^100
-      - scientificName:(*+-\"*+x+*\")^500
-      - taxonomicStatus:(*+-misapplied+-excluded+-miscellaneousLiterature+-inferredSynonym+-inferredAccepted)^1000
-      - idxtype:TAXON^2000
+    bq: bq=taxonomicStatus:accepted^2000&bq=rankID:7000^500&bq=rankID:6000^100&bq=scientificName:(*+-\"*+x+*\")^500&bq=taxonomicStatus:(*+-misapplied+-excluded+-miscellaneousLiterature+-inferredSynonym+-inferredAccepted)^1000&bq=idxtype:TAXON^2000
     fq:
       - NOT+idxtype:IDENTIFIER
       - NOT+idxtype:TAXONVARIANT
     defType: edismax
     qAlt: text:*
-    hl:
-      - true
-      - hl=true
-      - hl.fl=*
-      - hl.simple.pre=<b>
-      - hl.simple.post=</b>
+    hl: hl=true&hl.fl=*&hl.simple.pre=<b>&hl.simple.post=</b>
 skin:
   layout: main
   orgNameLong: Atlas of Living Australia

--- a/grails-app/services/au/org/ala/bie/SearchService.groovy
+++ b/grails-app/services/au/org/ala/bie/SearchService.groovy
@@ -153,7 +153,7 @@ class SearchService {
         query << "qf=${grailsApplication.config.solr.qf}" // dismax query fields
         query << "${grailsApplication.config.solr.bq}" // dismax boosts
         query << "q.alt=${grailsApplication.config.solr.qAlt}" // if no query specified use this query
-        query << "hl=${grailsApplication.config.solr.hl}" // highlighting parameters
+        query << "${grailsApplication.config.solr.hl}" // highlighting parameters
         query << "wt=json"
         query << "facet=${!requestedFacets.isEmpty()}"
         query << "facet.mincount=1"
@@ -838,6 +838,7 @@ class SearchService {
                         namePublishedInYear: taxon.namePublishedInYear,
                         namePublishedInID: taxon.namePublishedInID,
                         taxonRemarks: taxon.taxonRemarks,
+                        provenance: taxon.provenance,
                         infoSourceURL: taxon.source ?: taxonDatasetURL,
                         datasetURL: taxonDatasetURL
                 ],
@@ -861,6 +862,7 @@ class SearchService {
                             namePublishedInID: synonym.namePublishedInID,
                             nameAuthority: synonym.datasetName ?: datasetName ?: grailsApplication.config.synonymSourceAttribution,
                             taxonRemarks: synonym.taxonRemarks,
+                            provenance: synonym.provenance,
                             infoSourceURL: synonym.source ?: datasetURL,
                             datasetURL: datasetURL
                     ]
@@ -882,6 +884,7 @@ class SearchService {
                             isPlural: commonName.isPlural,
                             organismPart: commonName.organismPart,
                             taxonRemarks: commonName.taxonRemarks,
+                            provenance: commonName.provenance,
                             labels: commonName.labels,
                             infoSourceName: commonName.datasetName ?: datasetName ?: grailsApplication.config.commonNameSourceAttribution,
                             infoSourceURL: commonName.source ?: datasetURL,
@@ -904,6 +907,7 @@ class SearchService {
                             status: identifier.status,
                             subject: identifier.subject,
                             format: identifier.format,
+                            provenance: identifier.provenance,
                             infoSourceName: identifier.datasetName ?: datasetName ?: grailsApplication.config.identifierSourceAttribution,
                             infoSourceURL: identifier.source ?: datasetURL,
                             datasetURL: datasetURL
@@ -927,6 +931,7 @@ class SearchService {
                             namePublishedInID: variant.namePublishedInID,
                             nameAuthority: variant.datasetName ?: datasetName ?: grailsApplication.config.variantSourceAttribution,
                             taxonRemarks: variant.taxonRemarks,
+                            provenance: variant.provenance,
                             infoSourceName: variant.datasetName ?: datasetName ?: grailsApplication.config.variantSourceAttribution,
                             infoSourceURL: variant.source ?: datasetURL,
                             datasetURL: datasetURL,


### PR DESCRIPTION
Allow provenance and taxonRemarks to be multi-valued to accomodate appended information. Multiple entries are separated by a | in the source DwcA
Fix configuration for bq= and hl= modification