### PR TITLE
Changes to use solr API and solr 6.6.5 (with, in passing, a fix to issue 199)

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ An example vernacular name list configuration is
 {
   "defaultVernacularNameField": "name",
   "defaultNameIdField": "nameID",
+  "defaultKingdomField": "kingdom",
   "defaultStatusField": "status",
   "defaultLanguageField": "language",
   "defaultsourceField": "source",
@@ -213,6 +214,11 @@ An example vernacular name list configuration is
     {
       "uid": "drt1464664375273",
       "language": "xul"
+    },
+    {
+      "uid": "drt1464664375274",
+      "language": "fr",
+      "statusField": "priority"
     }
   ]
 }
@@ -237,6 +243,7 @@ An example conservation status list configuration is
 ```
 {
   "defaultSourceField": "status",
+  "defaultKingdomField": "kingdom",
   "lists": [
     {
       "uid": "dr656",
@@ -249,13 +256,16 @@ An example conservation status list configuration is
       "field": "conservationStatusVIC_s",
       "term": "conservationStatusVIC",
       "label": "VIC",
-      "sourceField": "statusName"
+      "sourceField": "statusName",
+      "kingdomField": "kgm"
     }
   ]
-}```
+}
+```
 
 The `uid` supplies the list identifier.
 The `field` supplies the solr field which will be used to store the conservation status.
 The `term` supplies the name of the status field.
 `label` gives the label to apply to the conservation status.
-`sourceField`
+`sourceField` gives the name of the field that contains the conservation status.
+`kingdomField` gives the name of the field that contains the kingdom -- handy for name lookups, if available.

--- a/build.gradle
+++ b/build.gradle
@@ -73,7 +73,7 @@ dependencies {
     compile 'org.grails.plugins:external-config:1.1.1'
 
     compile group: 'org.grails.plugins', name: 'ala-bootstrap3', version: '3.0.3', changing: true
-    compile(group: 'org.grails.plugins', name: 'ala-auth', version:'3.1.0-SNAPSHOT', changing: true) {
+    compile(group: 'org.grails.plugins', name: 'ala-auth', version:'3.1.0', changing: true) {
         exclude group: 'javax.servlet', module: 'servlet-api'
     }
     compile group: 'org.grails.plugins', name: 'ala-admin-plugin', version: '2.0', changing: true

--- a/build.gradle
+++ b/build.gradle
@@ -72,11 +72,11 @@ dependencies {
     compile "org.jsoup:jsoup:1.8.3"
     compile 'org.grails.plugins:external-config:1.1.1'
 
-    compile group: 'org.grails.plugins', name: 'ala-bootstrap3', version: '3.0.3', changing: true
-    compile(group: 'org.grails.plugins', name: 'ala-auth', version:'3.1.0', changing: true) {
+    compile group: 'org.grails.plugins', name: 'ala-bootstrap3', version: '3.0.3'
+    compile(group: 'org.grails.plugins', name: 'ala-auth', version:'3.1.0') {
         exclude group: 'javax.servlet', module: 'servlet-api'
     }
-    compile group: 'org.grails.plugins', name: 'ala-admin-plugin', version: '2.0', changing: true
+    compile group: 'org.grails.plugins', name: 'ala-admin-plugin', version: '2.0'
     compile "org.grails.plugins:grails-spring-websocket:2.3.0"
     //compile "org.grails.plugins:rxjava2:2.0.0"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -60,7 +60,7 @@ dependencies {
     }
 
     compile 'net.sf.opencsv:opencsv:2.3'
-    compile "org.apache.solr:solr-solrj:5.4.0"
+    compile "org.apache.solr:solr-solrj:6.6.5"
     compile("org.gbif:dwca-io:1.24") {
         exclude group: 'com.google.guava', module: 'guava'
     }
@@ -80,6 +80,9 @@ dependencies {
     compile "org.grails.plugins:grails-spring-websocket:2.3.0"
     compile 'org.webjars:swagger-ui:3.18.2'
     //compile "org.grails.plugins:rxjava2:2.0.0"
+
+    testCompile 'com.github.tomakehurst:wiremock:2.19.0'
+    testCompile 'com.github.tomjankes:wiremock-groovy:0.2.0'
 }
 
 bootRun {

--- a/doc/nameology/afd.md
+++ b/doc/nameology/afd.md
@@ -35,19 +35,36 @@ Since each taxon/name combination represents an edit, there may be multiple copi
 name, author and year combination in the name table.
 The disambiguation table assigns a single ID to each name/author/year.
 
+### Sanitization
+
+Rows from the input are checked for correct formatting:
+
+* Identifiers are sequences of digits.
+* GUIDs are UUIDs.
+* Flags are `0` (false) or `1` (true) with nothing defaulting to false.
+* Dates are of the form `dd-MMM-yy`.
+* Names have HTML elements removed and essential names are not empty.
+* Vocabulary terms from lookup tables have the form `XXX.YYY.ZZZ` eg taxon.rank.K.
+
+Care needs to be taken when providing input that long text, such as a reference qualification, that it is
+correctly enclosed in quotes and escaped, otherwise the row will be rejected.
+
 ## Currency
 
 The supplied AFD tables contain a complete history of all changes.
 To be current, a taxon needs to be:
 
-* Not unplaced
-* Not with a primary rank of `taxom.rank.SI` ([species inquirenda](glossary.md#def-species-inquirenda)) or
-`taxon.rank.IS` ([incertae sedis](glossary.md#def-incertae-sedis))
+* Not unplaced (ie with a specific unplaced flag)
 * A status of `taxon.status.P` (placed)
 * No end-date
 
-In addition, a useful taxon needs to have a matching name in the names table.
+Any taxon which does not meet the currency test is sent to either an unplaced or not previous taxon file.
+The previous taxon file is used to build an [ancestor trail](#ancestors) for the current taxon.
 
+A name is current if it has no end-date.
+
+In addition, a useful taxon needs to have a matching name in the names table.
+Taxa with missing names are placed in an unnamed file.
 
 ## Identification
 
@@ -64,6 +81,15 @@ for example http://biodiversity.org.au/afd.taxon/05d742b7-34fe-4d9e-936f-91cd213
 * A name LSID has the form `urn:lsid:biodiversity.org.au:afd.name:<disambiguated name id>`
 This LSID can be resolved to `http://biodiversity.org.au/afd.taxon/<disambiguated name id>` 
 for example http://biodiversity.org.au/afd.name/489144
+
+## Source Splitting
+
+Names are split according to the following rules:
+
+* Valid names are treated as accepted names and linked to a taxon
+* Synonyms or various sorts and excluded names are treated as synonyms
+* Common names, miscellaneous literature and legislative names are treated as vernacular names
+* Other names, such as associated flora, associated fauna, type species, etc. are discarded
 
 ## Annotation
 
@@ -86,9 +112,9 @@ An ancestor trail of previous taxa identifiers is built iteratively.
 Each taxon contains a column with the identifier of the previous version of the taxon.
 The ancestor trail is traversed to build a list of ancestors for each current taxon.
 
-## Parents
+### Parents
 
-There are several uncertain taxa in the AFD with accepted child taxa.
+There are possibly rejected taxa in the AFD with accepted child taxa.
 Once the list of current taxa has been generated an iterative process builds a table of actual parents.
 On each iteration, the parent ID for a taxon is bumped up to the parent with the next highest rank if
 the parent is not part of the list of accepted taxa.
@@ -99,6 +125,11 @@ Files are generated for accepted taxa, synonyms, vernacular names and previous t
 Accepted taxa and synonyms are checked against parents for rank inversions.
 
 Zoological practise is to include the accepted name for a taxon as a senior synonym.
-This is ignored, since all this does is gum the index up, 
+This is ignored, since all this does is gum the index up.
+
+Incerate sedis and species inquirenda status, for some reason, is supplied via the taxon rank.
+The senior synonym also holds the actual taxon name, rather than the name "Incertae sedis".
+The taxonomic status is coverted to the appropriate taxonomic status and the rank is converted to `unknown`
+when this appears.
 
 

--- a/doc/nameology/apni.md
+++ b/doc/nameology/apni.md
@@ -40,5 +40,12 @@ The names file contains the following:
 ### Names not in APC
 
 Some names in APNI have not yet been placed in the APC.
-These orphan names are treated as accepted taxa and placed under Plantae; we at least know which kingdom they come from.
+These orphan names are treated as inferred accepted taxa and placed under Plantae; 
+we at least know which kingdom they come from.
+Names that have been placed in the APC are given a different dataset identifier to those names
+that are only in APNI.
+
+It is theoretically possible to use the higher taxonomy in the names data to provide placement
+for APNI-only names and allow [merging](merging.md) to correctly link these names to parent taxa.
+This is not currently done.
 

--- a/doc/nameology/caab.md
+++ b/doc/nameology/caab.md
@@ -17,7 +17,7 @@ Multiple values are separated by vertical bars (|).
 ## Identification
 
 CAAB maintains a unique numeric *CAAB Code* for each species.
-These codes are not resolvable, and a taxonID is simply `CAAB:<CAAB ID>` for example `CAAB:24462004`
+These codes are not resolvable, and a taxonID is simply `<CAAB ID>` for example `24462004`
 
 Synonyms share the same identification as the parent species.
 These are given a unique identifier built from a hash of the species and synonym name.
@@ -25,17 +25,18 @@ For example, `CAAB:e405ef6a:93721fae:7ec56454:41ae634c`
 
 ## Currency
 
-Many of the species in CAAB are already in [AFD](afd.md).
-Prior to processing, species are matched against the existing list of species
-using [name matching](processing-basics.md#name-matching).
-Pre-existing species use the pre-existing taxonID and are not included in the final CAAB data.
+CAAB codes with the following identifier styles represent placeholder entries in CAAB
+for groupings of organisms that have not yet been analysed.
+These codes have a prefix of `8` or `99` and are marked as placeholders.
+Placeholder CAAB codes are not included in the output unless, by some fluke they have ended up as the parent of
+another taxon.
 
 ## Parents
 
 CAAB does not directly supply a parent identifier for a taxon.
 Instead, each taxon contains the names from each rank in the Linnaean hierarchy, along with a few additional
 sub- or super- ranks.
-These names are passed through to the resulting file, for use by the taxonomy builder.
+These names are passed through to the resulting file, for use by the [taxonomy builder](merging.md).
 
 ## DwCA Construction
 
@@ -44,4 +45,3 @@ After pre-processing, accepted taxa can be directly mapped onto the DwCA form.
 Synonyms and vernacular names are extracted from the lists of synonyms and common names and denormalised.
 separate tables are built for each type of name.
 
-An identifier table is built with the CAAB codes for each taxon.

--- a/doc/nameology/col.md
+++ b/doc/nameology/col.md
@@ -1,8 +1,7 @@
 # Catalogue of Life
 
 The [Catalogue of Life](http://www.catalogueoflife.org/) (CoL) is a global taxonomic catalogue.
-The ALA uses CoL for viruses, bacteria, protozoa, chromista and certain fungi that are not part of [AusFungi](ausfungi.md)
-but which need to be included.
+The ALA uses CoL for viruses, bacteria, protozoa, chromista and certain fungi that are found in Australia.
 
 ## Data Source
 
@@ -31,10 +30,12 @@ These identifiers are passed though and used when constructing the final ALA DwC
 The data supplied is a snapshot of the current domain.
 All information is current.
 
-Only Australian fungi (identified by a real distribution in Australia) that are not already in [AusFungi](ausfungi.md) are included,
+Data from the CoL is filtered by a series of kingdom, dataset and locality filters.
+For Fungi, only non-exitinct, Australian fungi (identified by a real distribution in Australia) are included,
 along with the higher taxa for Australian species.
 Higher taxa are identified by a similar process to [parent correction](processing-basics.md#correcting-parents).
-If a higher taxon is already in AusFungi, the identifier is replaced by the AusFungi taxonID.
+Many fungi are already present in [AusFungi](ausfungi.md) and are [merged](merging.md) with the AusFungi entries.
+
 
 ## Parents
 

--- a/doc/nameology/conventions.md
+++ b/doc/nameology/conventions.md
@@ -28,6 +28,9 @@ Some vocabulary:
 * A *taxon* is a group of organisms that share some sort of common characteritics.
 A taxon can have several names, one of which is the *valid* or *accepted* name.
 * A *synonym* is a name applied to a taxon that now goes by a different name.
+  Note that what the ALA regards as a synonym is somewhat looser than the use of the term in
+  the taxonomic community; all the ALA wants is to be able to say "this is now referred to as that"
+  so that supplied names and searches can be redirected.
 * A *taxonomic concept* is the placement of a particular taxon in the taxonomic tree in relation other taxa.
 
 The common identifier for a taxonomic DwCA is the [taxonID](http://rs.tdwg.org/dwc/terms/index.htm#taxonID).
@@ -37,6 +40,7 @@ The common identifier for a taxonomic DwCA is the [taxonID](http://rs.tdwg.org/d
 [Life Sciences Identifiers](http://www.omg.org/cgi-bin/doc?dtc/04-05-01) are resolvable [URNs](https://en.wikipedia.org/wiki/Uniform_Resource_Name) that can be used to identify a taxon, name or taxon concept. An LSID has the form *urn:lsid:&lt;authority&gt;:&lt;namespace&gt;:&lt;id&gt;* for example *urn:lsid:biodiversity.org.au:afd.taxon:bcd1b9ea-1cc1-4ab5-a15c-bbca5a987fb2* is a reference to an AFD taxon controlled by biodiversity.org.au. LSIDs can be resolved by going to the service at http://lsid.tdwg.org/
 
 LSIDs are preferred for identifiers, where possible, because they allow links to further information about the taxon.
+However, many sources use URLs, instead, for identifiers; these are also perfectly acceptable.
 
 ## <a name="taxonomic-status"/> Taxonomic Status
 
@@ -59,12 +63,16 @@ identification into two parts.
 | heterotypicSynonym | yes | A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. The zoological term is subjective synonym, since whether they are synonymns or not is a matter of opinion. |
 | subjectiveSynonym | yes | A taxonomic synonym, meaning that a species that was originally considered to be separate has been lumped into another species. The zoological term is subjective synonym, since whether they are synonymns or not is a matter of opinion. |
 | proParteSynonym | no | A synonym where part of an original taxon has been divided. This means that the original name may still be in use or may have been mapped onto several other taxa. Here be dragons. |
+| incertaeSedis | yes | A name of uncertain placement. This is generally treated as an accepted name with the placement supplied. |
+| speciesInquirena | yes | A species under enquiry. This is generally treated as an accepted name with the placement supplied. |
 | misapplied | no | A name incorrectly applied in a publication to a different species. However, the name itself is perfectly valid and has its own taxon. |
 | excluded | no | A name that shouldn't be used, since it refers to something not found in the region of the occurrence record. |
-| miscellaneousLiterature | no | A name that occurs in other literature. |
-| inferredAccepted | yes | A name treated as an accepted taxon by the processing software. Inferred markers indicate that the information has been deduced by the processing sofware, rather than explicitly supplied |
+| miscellaneousLiterature | no | A name that occurs in other literature. This will now be converted to a vernacular name, since it's not really a proper name for the|
+| invalid | no | A name that should not be. |
+| inferredAccepted | yes | A name treated as an accepted taxon by the processing software. Inferred markers indicate that the information has been deduced by the processing sofware, rather than explicitly supplied. |
 | inferredSynonym | no | A name treated as a synonym by the processing software |
 | inferredExcluded | no | A name treated as excluded by the processing software |
+| inferredInvalid | no | A name treated as invalid by the processing software |
 
 Informationm about the type of name is placed in the nomenclaturalStatus term.
 
@@ -196,7 +204,7 @@ Files with a .txt extension are tab-separated values (UTF-8, enclosing quotes of
 
 ### taxon.csv and taxonvariant.csv
 
-The produced taxon.csv contains scientific names (both accepted and synonyms) and information about the
+The produced taxon.csv contains scientific names (accepted, synonyms and odd fish like excluded) and information about the
 taxonomic tree.
 The taxonomic variant file contains the information from different sources that was used to make a specific taxon.
 It can contain the following columns

--- a/doc/nameology/index.md
+++ b/doc/nameology/index.md
@@ -25,6 +25,7 @@ the sort of taxonomic Darwin Core Archives that the bie-index expects.
     * [Codes for Australian Aquatic Biota](caab.md)
     * [New Zealand Organism Register](nzor.md)
     * [Catalogue of Life](col.md)
+* [Merging](merging.md)
 
 ## The Goal
 
@@ -33,7 +34,9 @@ The ALA uses scientific names and taxonomic trees for specific purposes.
 Essentially, the ALA is matching names so that it can build an index of occurrence
 records by species and we want both to join like with like and build an index tree so
 that people can find records across higher taxa, so that "find me all birds" becomes
-"find all records indexed to class:AVES"
+"find all records indexed to class:AVES".
+We also build a search index of names, data sources, localities, etc. that can be used
+by humans to find what they are looking for.
 
 The ALA is *not* in the business of providing some sort of absolute truth.
 This is because the ALA collects occurrence records from across time, space and sanity:
@@ -60,9 +63,12 @@ To do this we do the following:
 * Build a taxonomic tree where each taxon concept has a place in the tree.
 We know that there are a least as many taxonomic trees as there are taxonomists.
 The ALA, where possible, takes the "official" taxonomic trees of the 
-Australian Faunal Directory (AFD) and the Australian Plant Census (AFC) of the Australian Plant Name Index (APNI).
+Australian Faunal Directory (AFD), the Australian Plant Census (AFC) of the Australian Plant Name Index (APNI)
+and the New Zealand Organisms Register (NZOR).
 These "official" trees are essentially the state of the art for anyone who doesn't have a dog in this fight.
 They have some holes in them, so they're supplemented by various other sources.
+  * Where the sources double up or disagree, a [merging](merging.md) step resolves the taxonomies against
+    each other.
 * Build an index of names where each name is mapped onto a place in the taxonomic tree. 
 These names include synonyms (names for species that now go by a different, correct name) and
 vernacular names (commonly used names for species)
@@ -82,13 +88,16 @@ Generally, if a name/author occurs in an earlier source, then the identifier and
 used and identifiers are mapped in following sources.
 The order of priority for sources is:
 
+1. AusFungi (for fungi only)
+1. AusMoss (for mosses only)
 1. Australian Faunal Directory
-2. Australian Plant Name Index/Australian Plant Census
-3. AusFungi
-4. AusMoss
-5. Codes for Australian Aquatic Biota
-6. New Zealand Organism Register
-7. Catalogue of Life
+1. Australian Plant Name Index/Australian Plant Census
+1. New Zealand Organism Register
+1. Australian Plant Name Index (names only)
+1. Codes for Australian Aquatic Biota
+1. Catalogue of Life
+1. Names generated from species lists held by the ALA, such as threatened species lists, special cases
+   and lists of vernacular names.
 
 There are some cases where source disagree on classification to the point where the same species appears
 at a different rank or with different parents.

--- a/doc/nameology/merging.md
+++ b/doc/nameology/merging.md
@@ -1,0 +1,65 @@
+# Merging Taxonomies
+
+The resulting set of DwCAs procuded by the processing are combined in the
+Large Taxon Collider, documented [here](https://github.com/AtlasOfLivingAustralia/ala-name-matching/blob/master/doc/large-taxon-collider.md).
+
+The ALA uses the following [configuration](https://github.com/AtlasOfLivingAustralia/ala-name-matching/blob/master/data/ala-taxon-config.json)
+documented [here](https://github.com/AtlasOfLivingAustralia/ala-name-matching/blob/master/doc/merge-config.md).
+The configuration has the following properties:
+
+## General Rules
+
+These rules are common to all sources, unless overridden.
+
+### Forbidden
+
+Taxa with a taxonomic status of invalid or inferred invalid are eliminated.
+Previously, incertae sedis taxa were also eliminated.
+
+### Score Adjustments
+
+* Taxa with less than perfect taxonomic status, such as unplaced taxa, inferred status, etc. have scores adjusted downwards.
+  This means that cleanly accepted and synonym taxa are chosen as principals, if available.
+* Taxa with names not handled well by the current name matching algorithms, eg. hybrids, or names that imply
+  problems, eg. doubtful names or names with unplaced in them have scores adjusted downwards.
+* Taxa with a dodgey nomenclatural status, such as illegitimate or denied, have scores adjusted downwards.
+
+### Key Adjustments
+
+Note that key adjustments only affect name keys for the purposes of deciding whether two taxa from
+different sources are "the same".
+
+* Ranks are collapsed into broad families. For example, superclass, class, subclass, infraclass and subinfraclass
+  are all mapped onto class.
+  This means that slight differences in opinion on placement between sources do not affect merging.
+
+### Cutoff
+
+Taxa with scores below 500 will, generally, not be considered as principals for resolution
+unless there are no other options.
+This cutoff score ensures that inferred accepted taxa coming from the ALA species lists, 
+which have a base score of 0, are not considered if there are other variants, perhaps excluded or invalid, 
+from more authoritative sources.
+  
+## Sources
+
+### Forbidden
+
+"Root" taxon concepts, tying all top-level taxa together, are eliminated.
+
+### Special Significance
+
+AusMoss and AusFungi have boosted scores for Bryophyta/Bryidae and Fungi, respectively.
+In these cases their taxonomy will tend to override APC.
+APC has boosted scores for Plantae and AFD has boosted scores for Animalia.
+
+### Ownership
+
+AusFungi owns Fungi, meaning that other taxon concepts for Fungi are mapped onto the
+AusFungi taxon concept by inferred synonyms.
+Similarly, APC owns Plantae.
+
+### Key Adjustments
+
+Viruses from the Catalogue of Life is mapped onto the Virus used by everyone else.
+

--- a/doc/nameology/processing-basics.md
+++ b/doc/nameology/processing-basics.md
@@ -3,6 +3,9 @@
 Going from a bunch of files to a shiney new DwCA tends to follow more or less the same pattern,
 no matter how ropey and deranged the originating data is.
 
+The general principle is to identify current data, reformat it into DwCA form and pass it on.
+The [merging](merging.md) step decides which of the resulting taxa is used
+
 ## Tools
 
 [Talend OS](http://www.talend.com/) is used as a processing engine.
@@ -32,13 +35,35 @@ structured so that further processing steps can proceed.
 
 Before use, source files should be sanitized.
 This means checking that the fields you use contain data that looks like it should be there.
-Generally, this involves:
+For example, for an AFD taxon file, sanitization consists of:
+
+* The TAXON_ID is present and is a sequence of digits
+* The PARENT_ID is absent or is a sequence of digits
+* The TAXON_GUID is present and is formatted as a UUID
+* The PRIMARY_RANK is present and is of the form `taxon.rank.XXXX`
+* The UNPLACED field is absent or one of `0` or `1`
+* The UNPUBLISHED field is absent or one of `0` or `1`
+* The RESTRICTED field is absent or one of `0` or `1`
+* The RANK_PREFIX field is absent or is a sequence of letters
+* The ORDER_INDEX field is absent of is a sequence of digits
+* The LEGACY_TAXON_ID field is absent of is a sequence of digits
+* The DRAFT field is absent or one of `0` or `1`
+* The START_DATE field is present and is a date of the form `dd-MMM-yy` (eg 19-AUG-09)
+* The END_DATE field is absent or is a date of the form `dd-MMM-yy`
+* The CREATED_FROM_ID field is absent of is a sequence of digits
+* The STATUS is present and is of the form `taxon.status.XXXX`
+* The DRAFT_NAME_ONLY field is absent or one of `0` or `1`
+* The ASSIGNED_TAXON_ID field is absent of is a sequence of digits
+
+Sanitization at least consists of:
 
 * Checking to see whether identifiers pass muster
 * Checking to see whether there is a name at all.
 It would be nice to be able to check to see whether the name fits the established rules for
 the branch of biology but this is almost always a fool's errand.
 [Phrase names](glossary.md#def-phrase-name) and the like usually play merry hell with whatever rules you come up with.
+
+Rows that do not pass sanitization tests are placed in a rejected file, for further examination.
 
 ### Cleaning
 
@@ -49,7 +74,6 @@ In particular, year of publication seems to cause a desire to prevaricate in way
 
 Data that contains historical trails of information needs to be filtered so that only the current
 view of names and taxonomy is used.
-[Incertae Sedis](glossary.md#def-incertae-sedis) taxa of doubtful position may also be eliminated at this point.
 
 If the data contains historical trails, it may be possible to build a trail of ancestor identifiers
 that can be used to provide a service for clients not yet up to date. 
@@ -58,8 +82,9 @@ that can be used to provide a service for clients not yet up to date.
 ### Identification
 
 Adding taxonIDs to the various taxa, along with notes as to whether they are to be used or not.
-Minor sources of names often duplicate taxa that have already been processed.
-Identification involves mapping taxa onto pre-existing identifiers, or building new identifiers for the incoming taxa.
+In some cases, there are internal identifiers (eg. a row number in a database or UUID) and external identifiers
+(eg. an LSID or URL) that are linked to the internal identifiers.
+The output should use the external identifiers.
 
 Where necessary, the supplied identifier is left in place  and a parallel `identifier` column is used
 to carry the final identifier.
@@ -87,7 +112,7 @@ These are proceessed during [merging](#combining-sources).
 
 ### <a name="correcting-parents"/> Correcting Parents
 
-Some taxa may have non-current or incertae sedis parents.
+Some taxa may have non-current or otherwise eliminated parents.
 If these have been eliminated during pre-processing, then the parent taxon needs to be bumped up to the 
 current taxon of the next highest rank.
 
@@ -144,7 +169,7 @@ Once packaged, the resulting DwCA can be delivered to the BIE index.
 .
 * TODO (Potentially, it may not be worth it) Dynamically build the meta.xml file.
 
-## <a name="combining-sources"/> Combining Sources
+## Combining Sources
 
 Once constructed, the resulting data is fed into the taxonomy builder,
 implemented in [ala-name-matching](https://github.com/AtlasOfLivingAustralia/ala-name-matching).

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -98,28 +98,69 @@ endpoints:
 #Required so that the gbif-ecat library does not bugger up initialisation from its internal application.properties
 app:
   dataDir: /tmp/gbif-ecat
-indexLiveBaseUrl: http://localhost:8080/solr/bie
-indexOfflineBaseUrl: http://localhost:8080/solr/bie-offline
-biocacheService:
-  baseUrl: https://biocache.ala.org.au/ws
+search:
+  highlight:
+    join: <br>
+autocomplete:
+  legacy: false
+  languages:
 biocache:
-  solr:
-    url: http://localhost:8080/solr/biocache
-defaultNameSourceAttribution: National Species Lists
-commonNameSourceAttribution: National Species Lists
+  base: https://biocache.ala.org.au
+  service: https://biocache.ala.org.au/ws
+  search: /occurrences/search
+  occurrenceCount:
+    path: /occurrences/taxaCount?guids={0}&separator={1}
+    enabled: true
+    # List of filters
+    filterQuery:
+    - geospatial_kosher:true
+  image:
+    path: /occurrences/search?q=${0}+AND+multimedia:Image&pageSize=5&facet=false
+    enabled: true
+    # List of filters
+    filterQuery:
+    - geospatial_kosher:true
+collectory:
+  base: https://collections.ala.org.au
+  service: https://collections.ala.org.au/ws
+  resources: /{0}
+  # A list of uids for the national species list datasets
+  nationalSpeciesDatsets:
+layers:
+  service: https://spatial.ala.org.au/ws
+  layers: /layers
+  layer: /layer/{0}?enabledOnly=false
+  objects: /objects/csv/cl{0}
+  gazetteerId: 2123
+  temporaryFilePattern: /tmp/objects_{0}.csv.gz
+images:
+  # URL of image configuration file
+  config: /default-image-lists.json
+  base: https://images.ala.org.au
+  service:
+    base:
+    thumbnail: https://images.ala.org.au/image/proxyImageThumbnail?imageId={0}
+    large: https://images.ala.org.au/image/proxyImage?imageId={0}
+    small: https://images.ala.org.au/image/proxyImageThumbnailLarge?imageId={0}
+    metadata: https://images.ala.org.au/ws/image/{0}
+  index: true
+wordPress:
+  service: https://www.ala.org.au
+  sitemap: /sitemap.xml
+  page: /?page_id={0}
+  excludedCategories:
+  - button
+  contentOnlyParams: ?content-only=1&categories=1
+lists:
+  service: https://lists.ala.org.au/ws
+  items: /speciesListItems/{0}?includeKVP=true
+# If attribution entry is null, the default is used
+attribution:
+  default: National Species Lists
+  common:
+  identifier:
+  synonym:
 commonNameDefaultLanguage: en-AU
-identifierSourceAttribution: National Species Lists
-indexImages: true
-collectoryBaseUrl: https://collections.ala.org.au
-collectoryServicesUrl: https://collections.ala.org.au/ws
-layersServicesUrl: https://spatial.ala.org.au/ws
-imageThumbnailUrl: https://images.ala.org.au/image/proxyImageThumbnail?imageId=
-imageLargeUrl: https://images.ala.org.au/image/proxyImage?imageId=
-imageSmallUrl: https://images.ala.org.au/image/proxyImageThumbnailLarge?imageId=
-imageMetaDataUrl: https://images.ala.org.au/ws/image/
-synonymCheckingEnabled: true
-synonymSourceAttribution: National Species Lists
-gazetteerLayerId: 2123
 security:
   apikey:
     serviceUrl: 'https://auth.ala.org.au/apikey/ws/check?apikey='
@@ -127,15 +168,6 @@ security:
     appServerName: https://bie.ala.org.au/ws
     uriFilterPattern: "/admin.*,/alaAdmin.*"
     uriExclusionFilterPattern: "/images.*,/css.*,/js.*,.*json,/help/.*"
-wordPress:
-    sitemapUrl: https://www.ala.org.au/sitemap.xml
-    baseUrl: https://www.ala.org.au/?page_id=
-    excludedCategories:
-      - button
-    contentOnlyParams: ?content-only=1&categories=1
-speciesList:
-  url: https://lists.ala.org.au/ws/speciesListItems/
-  params: ?includeKVP=true
 # Acceptable vernacular names to appear in autocomplete
 #autoComplete.languages = 'en,en-AU,en-CA,en-GB,en-US'
 autoComplete:
@@ -144,35 +176,57 @@ autoComplete:
 conservationListsUrl: /default-conservation-lists.json
 # Location of vernacular name lists (null for default)
 vernacularListsUrl: /default-vernacular-lists.json
-# Location of image lists (null for default)
-imagesListsUrl: /default-image-lists.json
 # Location of locality keywords (null for default)
 localityKeywordsUrl: /default-locality-keywords.json
 #nationalSpeciesDatasets: dr2699,dr2700,dr2702,dr2704,dr2703,dr3118
 nationalSpeciesDatasets: ""
-defaultDownloadFields: guid,rank,scientificName,establishmentMeans,rk_genus,rk_family,rk_order,rk_class,rk_phylum,rk_kingdom,datasetName
+defaultDownloadFields: guid,rank,scientificName,scientificNameAuthorship,taxonomicStatus,establishmentMeans,rk_genus,rk_family,rk_order,rk_class,rk_phylum,rk_kingdom,datasetName,parentGuid,acceptedConceptName,acceptedConceptID
 additionalResultFields: ""
 #toggle for the population of occurrence counts
-occurrenceCounts:
-  enabled: true
-  filterQuery: geospatial_kosher:true
 
 # Score normal value (divides integer priority by the norm to give solr boosts)
-priority:
-  norm: 4000
-  min: 0.25
-  max: 5.0
 
-# SOLR additional params
+# SOLR additional params and connections
 solr:
-    qf: scientificName^1000+commonName^500+exact_text^200+doc_name^100+text
-    bq: bq=taxonomicStatus:accepted^2000&bq=rankID:7000^500&bq=rankID:6000^100&bq=scientificName:(*+-\"*+x+*\")^500&bq=taxonomicStatus:(*+-misapplied+-excluded+-miscellaneousLiterature+-inferredSynonym+-inferredAccepted)^1000&bq=idxtype:TAXON^2000
+    live:
+      type: HTTP
+      connection: http://localhost:8080/solr/bie
+      queueSize: 10
+      threadCount: 4
+    updatingLive:
+      type: UPDATE
+      connection: http://localhost:8080/solr/bie
+      queueSize: 10
+      threadCount: 4
+    offline:
+      type: UPDATE
+      conenction: http://localhost:8080/solr/bie-offline
+      queueSize: 10
+      threadCount: 4
+    qf:
+      - scientificName^1000
+      - commonName^500
+      - exact_text^200
+      - doc_name^100
+      - text
+    bq:
+      - taxonomicStatus:accepted^2000
+      - rankID:7000^500
+      - rankID:6000^100
+      - scientificName:(* -\"* x *\")^500
+      - taxonomicStatus:(* -misapplied -excluded -miscellaneousLiterature -inferredSynonym -inferredAccepted)^1000
+      - idxtype:TAXON^2000
     fq:
-      - NOT+idxtype:IDENTIFIER
-      - NOT+idxtype:TAXONVARIANT
+      - NOT idxtype:IDENTIFIER
+      - NOT idxtype:TAXONVARIANT
     defType: edismax
     qAlt: text:*
-    hl: hl=true&hl.fl=*&hl.simple.pre=<b>&hl.simple.post=</b>
+    hl:
+      hl: true
+      fl: "*"
+      simple:
+        pre: <b>
+        post: </b>
 skin:
   layout: main
   orgNameLong: Atlas of Living Australia
@@ -181,3 +235,8 @@ import:
   sequence: collectory,taxonomy-all,vernacular,denormalise,layers,regions,localities,conservation-lists,wordpress,link-identifiers,images,occurrences
   taxonomy:
     dir: /data/bie/import
+  priority:
+    norm: 4000
+    min: 0.25
+    max: 5.0
+

--- a/grails-app/conf/default-image-lists.json
+++ b/grails-app/conf/default-image-lists.json
@@ -1,9 +1,6 @@
 {
-  "boosts": [
-    "record_type:Image^10",
-    "record_type:HumanObservaton^20",
-    "record_type:Observation^20",
-    "-record_type:PreservedSpecimen^20"
+  "filters": [
+    "-record_type:PreservedSpecimen"
   ],
   "ranks": [
     {

--- a/grails-app/conf/example-conservation-lists.json
+++ b/grails-app/conf/example-conservation-lists.json
@@ -1,5 +1,6 @@
 {
   "defaultSourceField": "status",
+  "defaultKingdomField": "kingdom",
   "lists": [
     {
       "uid": "dr656",

--- a/grails-app/conf/spring/resources.groovy
+++ b/grails-app/conf/spring/resources.groovy
@@ -1,11 +1,25 @@
-import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient
-import org.apache.solr.client.solrj.impl.HttpSolrClient
+import au.org.ala.bie.solr.SolrClientBean
 import au.org.ala.bie.util.ConservationListsSource
 
 // Place your Spring DSL code here
 beans = {
-    liveSolrClient(HttpSolrClient, application.config.indexLiveBaseUrl)
-    offlineSolrClient(ConcurrentUpdateSolrClient, application.config.indexOfflineBaseUrl, 10, 4)
-    updatingLiveSolrClient(ConcurrentUpdateSolrClient, application.config.indexLiveBaseUrl, 10, 4)
+    liveSolrClient(SolrClientBean,
+        application.config.solr.live.type,
+        application.config.solr.live.connection,
+        application.config.solr.live.queueSize as Integer,
+        application.config.solr.live.threadCount as Integer
+    )
+    offlineSolrClient(SolrClientBean,
+        application.config.solr.offline.type,
+        application.config.solr.offline.connection,
+        application.config.solr.offline.queueSize as Integer,
+        application.config.solr.offline.threadCount as Integer
+    )
+    updatingLiveSolrClient(SolrClientBean,
+        application.config.solr.updatingLive.type,
+        application.config.solr.updatingLive.connection,
+        application.config.solr.updatingLive.queueSize as Integer,
+        application.config.solr.updatingLive.threadCount as Integer
+    )
     conservationListsSource(ConservationListsSource, application.config.conservationListsUrl)
 }

--- a/grails-app/controllers/au/org/ala/bie/ImportController.groovy
+++ b/grails-app/controllers/au/org/ala/bie/ImportController.groovy
@@ -118,7 +118,7 @@ class ImportController {
      */
     // Documented in openapi.yml
     def importCollectory(){
-        if(grailsApplication.config.collectoryServicesUrl){
+        if(grailsApplication.config.collectory.service){
             def job = execute("importCollectory", "admin.button.importcollectory", { importService.importCollectory() })
             asJson(job.status())
         } else {
@@ -133,11 +133,11 @@ class ImportController {
      */
     // Documented in openapi.yml
     def importLayers(){
-        if(grailsApplication.config.layersServicesUrl){
+        if(grailsApplication.config.layers.service){
             def job = execute("importLayers", "admin.button.importlayer", { importService.importLayers() })
             asJson(job.status())
         } else {
-            asJson([success: false, message: 'layersServicesUrl not configured'])
+            asJson([success: false, message: 'layers.service not configured'])
         }
     }
 
@@ -148,11 +148,11 @@ class ImportController {
      */
     // Documented in openapi.yml
     def importLocalities(){
-        if(grailsApplication.config.layersServicesUrl && grailsApplication.config.gazetteerLayerId){
+        if(grailsApplication.config.layers.service && grailsApplication.config.layers.gazetteerId){
             def job = execute("importLocalities", "admin.button.importlocalities", { importService.importLocalities() })
             asJson(job.status())
         } else {
-            asJson([success: false, message: 'layersServicesUrl not configured or gazetteerLayerId not configured'])
+            asJson([success: false, message: 'layers.services not configured or layers.gazetteerId not configured'])
         }
     }
 
@@ -163,11 +163,11 @@ class ImportController {
      */
     // Documented in openapi.yml
     def importRegions(){
-        if(grailsApplication.config.layersServicesUrl){
+        if(grailsApplication.config.layers.service){
             def job = execute("importRegions", "admin.button.importregions", { importService.importRegions() })
             asJson(job.status())
         } else {
-            asJson([success: false, message: 'layersServicesUrl not configured'])
+            asJson([success: false, message: 'layers.service not configured'])
         }
     }
 
@@ -246,7 +246,7 @@ class ImportController {
 
     /**
      * Reads preferred images list in list tool and updates imageId if values have changed
-     * list DR is defined by config var ${imagesListsUrl} - property {lists}
+     * list DR is defined by config var ${images.config} - property {lists}
      *
      * @return
      */

--- a/grails-app/controllers/au/org/ala/bie/SearchController.groovy
+++ b/grails-app/controllers/au/org/ala/bie/SearchController.groovy
@@ -1,6 +1,8 @@
 package au.org.ala.bie
 
 import grails.converters.JSON
+import au.org.ala.bie.util.Encoder
+
 /**
  * A set of JSON based search web services.
  */
@@ -198,26 +200,20 @@ class SearchController {
      */
     // Documented in openapi.yml
     def auto(){
-        log.debug("auto called with q = " + params.q)
-        log.debug("auto called with queryString = " + request.queryString)
         def fq = []
         def limit = params.limit
         def idxType = params.idxType
         def geoOnly = params.geoOnly
 
-        if (limit) {
-            fq << "&rows=${limit}"
-        }
-
         if (idxType) {
-            fq << "&fq=idxtype:${idxType.toUpperCase()}"
+            fq << "idxtype:${idxType.toUpperCase()}"
         }
 
         if (geoOnly) {
             // TODO needs WS lookup to biocache-service (?)
         }
 
-        def autoCompleteList = autoCompleteService.auto(params.q, fq)
+        def autoCompleteList = autoCompleteService.auto(params.q, fq, limit)
         def payload = [autoCompleteList:autoCompleteList]
         asJson payload
     }

--- a/grails-app/services/au/org/ala/bie/BieAuthService.groovy
+++ b/grails-app/services/au/org/ala/bie/BieAuthService.groovy
@@ -9,8 +9,8 @@ class BieAuthService {
 
     def checkApiKey(key) {
         // try the preferred api key store first
-        def url = grailsApplication.config.security.apikey.serviceUrl + key
-        def conn = new URL(Encoder.encodeUrl(url)).openConnection()
+        def url = grailsApplication.config.security.apikey.serviceUrl + Encoder.escapeQuery(key)
+        def conn = new URL(url).openConnection()
         if (conn.getResponseCode() == 200) {
             String resp = conn.content.text as String
             return JSON.parse(resp)

--- a/grails-app/services/au/org/ala/bie/BiocacheService.groovy
+++ b/grails-app/services/au/org/ala/bie/BiocacheService.groovy
@@ -1,0 +1,92 @@
+package au.org.ala.bie
+
+import au.org.ala.bie.search.IndexDocType
+import au.org.ala.bie.util.Encoder
+import grails.converters.JSON
+import grails.transaction.Transactional
+import groovy.json.JsonSlurper
+
+/**
+ * Biocache service API
+ */
+class BiocacheService {
+    def grailsApplication
+
+    /** Separator for multi-guid queries */
+    static SEPARATOR = ','
+    /** Default encoding */
+    static ENCODING = "UTF-8"
+
+    /**
+     * Get counts via taxon guids.
+     * <p>
+     * If the connection to the biocache fails, then an empty map is returned.
+     * </p>
+     * <p>
+     * A standard filter query is applied to the
+     *
+     * @param guids The list of guids to get
+     * @param fq And filter queries
+     *
+     * @return A map of guid -> count
+     *
+     */
+    def counts(List guids, List fq = []) {
+        def slurper = new JsonSlurper()
+        def guidParam = guids.join(SEPARATOR)
+        def url = Encoder.buildServiceUrl(grailsApplication.config.biocache.service, grailsApplication.config.biocache.occurrenceCount.path, guidParam, SEPARATOR, grailsApplication.config.biocache.occurrenceCount.filterQuery)
+        if (fq) {
+            def fqParam = fq?.collect({ "fq=${Encoder.escapeQuery(it)}" }).join('&')
+            url = new URL(url.toExternalForm() + '&' + fqParam)
+        }
+        def conn = url.openConnection()
+        try {
+            conn.setRequestMethod("GET")
+            conn.setDoOutput(false)
+            conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
+            conn.setRequestProperty("Accept-Charset", ENCODING);
+            return slurper.parse(conn.inputStream, ENCODING)
+        } catch (SocketTimeoutException e) {
+            log.error("Timed out calling web service. URL= ${url}.", e)
+            return [:]
+        } catch (Exception e) {
+            log.error("Failed calling web service. ${e.getMessage()} URL= ${url}. statusCode: ${conn?.responseCode} detail: ${conn?.errorStream?.text}", e)
+            return [:]
+        }
+    }
+
+    /**
+     * Search the biocache for matching occurrences
+     *
+     * @param q The query
+     * @param fq Filter queries (empty by default)
+     * @param facets Any facets (emopty by default)
+     * @param rows The number of rows to return (10 buy default)
+     * @param start The start position (0 by default)
+     * @param sort The sort field (null by default)
+     * @param dir The sor direection ('asc' or 'desc')
+     *
+     * @return The results of the query
+     */
+    def search(String q, List fq = [], facets = [], rows = 10, start = 0, sort = null, dir = 'asc') {
+        def slurper = new JsonSlurper()
+        def query = []
+        query << "q=${Encoder.escapeQuery(q)}"
+        fq.each { query << "fq=${Encoder.escapeQuery(it)}" }
+        if (!facets) {
+            query << "facet=false"
+        } else {
+            query << "facet=true"
+            query << "facets=${Encoder.escapeQuery(facets.join(","))}"
+        }
+        query << "pageSize=${rows}"
+        query << "startIndex=${start}"
+        if (sort) {
+            query << "sort=${Encoder.escapeQuery(sort)}"
+            query << "dir=${Encoder.escapeQuery(dir)}"
+        }
+        def url = grailsApplication.config.biocache.service + grailsApplication.config.biocache.search + '?' + query.join('&')
+        def response = url.toURL().getText("UTF-8")
+        return slurper.parseText(response)
+    }
+}

--- a/grails-app/services/au/org/ala/bie/CollectoryService.groovy
+++ b/grails-app/services/au/org/ala/bie/CollectoryService.groovy
@@ -1,0 +1,38 @@
+package au.org.ala.bie
+
+import au.org.ala.bie.util.Encoder
+import groovy.json.JsonSlurper
+
+/**
+ * Interface to the collectory
+ */
+class CollectoryService {
+    def grailsApplication
+
+    /**
+     * Get a list of available collectory resources of a specific type
+     *
+     * @param type The type of resource
+     *
+     * @return The list of available resoureces
+     */
+    def resources(String type) {
+        def url = Encoder.buildServiceUrl(grailsApplication.config.collectory.service, grailsApplication.config.collectory.resources, type)
+        def slurper = new JsonSlurper()
+        def json = slurper.parseText(url.getText('UTF-8'))
+        return json
+    }
+
+    /**
+     * Get the contents of a collectory entry/resource
+     *
+     * @param url The resource url
+     *
+     * @return The entity description contents
+     */
+    def get(url) {
+        def slurper = new JsonSlurper()
+        def json = slurper.parseText(url.toURL().getText('UTF-8'))
+        return json
+    }
+}

--- a/grails-app/services/au/org/ala/bie/DownloadService.groovy
+++ b/grails-app/services/au/org/ala/bie/DownloadService.groovy
@@ -29,16 +29,13 @@ class DownloadService {
      * @return
      */
     def download(params, OutputStream outputStream, Locale locale){
-        def q = params.q ?: "*:*"
+        def q = Encoder.escapeQuery(params.q ?: "*:*")
         def fq = ""
-        def fields = grailsApplication.config.defaultDownloadFields?:"guid,rank,scientificName,rk_genus,rk_family,rk_order,rk_class,rk_phylum,rk_kingdom,datasetName"
+        def fields = params.fields ?: grailsApplication.config.defaultDownloadFields ?: "guid,rank,scientificName,rk_genus,rk_family,rk_order,rk_class,rk_phylum,rk_kingdom,datasetName"
 
-        if (params.fields) {
-            fields = params.fields
-        }
-
+        fields = Encoder.escapeQuery(fields)
         if (params.fq) {
-            String fqs = params.list("fq").join("&fq=")
+            String fqs = params.list("fq").collect({ Encoder.escapeQuery(it) }).join("&fq=")
             fq = "&fq=${fqs}"
         }
 
@@ -46,7 +43,7 @@ class DownloadService {
                 fields + "&csv.header=false&rows=" + Integer.MAX_VALUE +
                 "&q=${q}${fq}"
 
-        def connection = new URL(Encoder.encodeUrl(queryUrl)).openConnection()
+        def connection = new URL(queryUrl).openConnection()
         def input = connection.getInputStream()
         def headers = []
 

--- a/grails-app/services/au/org/ala/bie/ImportService.groovy
+++ b/grails-app/services/au/org/ala/bie/ImportService.groovy
@@ -2149,9 +2149,9 @@ class ImportService {
             return nameFormatted
         if (nameComplete) {
             def authorIndex = scientificNameAuthorship ? nameComplete.indexOf(scientificNameAuthorship) : -1
-            if (authorIndex < 0)
+            if (authorIndex <= 0)
                 return "<span class=\"${formattedCssClass}\">${StringEscapeUtils.escapeHtml(nameComplete)}</span>"
-            def preAuthor = nameComplete.substring(0, authorIndex - 1).trim()
+            def preAuthor = nameComplete.substring(0, authorIndex).trim()
             def postAuthor = nameComplete.substring(authorIndex + scientificNameAuthorship.length()).trim()
             def name = "<span class=\"${formattedCssClass}\">"
             if (preAuthor && !preAuthor.isEmpty())

--- a/grails-app/services/au/org/ala/bie/ImportService.groovy
+++ b/grails-app/services/au/org/ala/bie/ImportService.groovy
@@ -18,6 +18,8 @@ import au.org.ala.bie.indexing.RankedName
 import au.org.ala.bie.search.IndexDocType
 import au.org.ala.bie.util.Encoder
 import au.org.ala.bie.util.TitleCapitaliser
+import au.org.ala.names.model.RankType
+import au.org.ala.names.model.TaxonomicType
 import au.org.ala.vocab.ALATerm
 import grails.async.PromiseList
 import grails.converters.JSON
@@ -28,6 +30,7 @@ import org.apache.commons.lang.StringEscapeUtils
 import org.apache.commons.lang.StringUtils
 import org.apache.solr.client.solrj.util.ClientUtils
 import org.apache.solr.common.params.MapSolrParams
+import org.gbif.api.vocabulary.TaxonomicStatus
 import org.gbif.dwc.terms.*
 import org.gbif.dwca.io.Archive
 import org.gbif.dwca.io.ArchiveFactory
@@ -78,6 +81,12 @@ class ImportService {
             DwcTerm.taxonRemarks,
             DcTerm.provenance
     ] as Set
+    // Count report interval
+    static REPORT_INTERVAL = 100000
+    // Batch size for solr queries/commits and page sizes
+    static BATCH_SIZE = 5000
+    // Buffer size for commits
+    static BUFFER_SIZE = 1000
 
 
     def indexService, searchService
@@ -319,7 +328,7 @@ class ImportService {
 
                     batch << doc
 
-                    if (batch.size() > 10000) {
+                    if (batch.size() > BATCH_INTERVAL) {
                         indexService.indexBatch(batch)
                         batch.clear()
                     }
@@ -630,7 +639,7 @@ class ImportService {
      **/
     def importOccurrenceData() throws Exception {
         String nationalSpeciesDatasets = grailsApplication.config.nationalSpeciesDatasets // comma separated String
-        def pageSize = 10000
+        def pageSize = BATCH_SIZE
         def paramsMap = [
                 q: "taxonomicStatus:accepted", // "taxonomicStatus:accepted",
                 //fq: "datasetID:dr2699", // testing only with AFD
@@ -744,7 +753,7 @@ class ImportService {
      * @return
      */
     def indexDocInQueue(Queue updateDocs, msg) {
-        int batchSize = 1000
+        int batchSize = BUFFER_SIZE
 
         while (isKeepIndexing || updateDocs.size() > 0) {
             if (updateDocs.size() > 0) {
@@ -1150,8 +1159,9 @@ class ImportService {
 
             buffer << doc
             counter++
-            if (buffer.size() >= 1000) {
-                log("Adding taxa: ${counter}")
+            if (buffer.size() >= BUFFER_SIZE) {
+                if (counter % REPORT_INTERVAL == 0)
+                    log("Adding taxa: ${counter}")
                 indexService.indexBatch(buffer)
                 buffer.clear()
             }
@@ -1233,10 +1243,11 @@ class ImportService {
             }
             buffer << doc
             count++
-            if (buffer.size() >= 1000) {
+            if (buffer.size() >= BUFFER_SIZE) {
                 indexService.indexBatch(buffer)
                 buffer.clear()
-                log("Processed ${count} records")
+                if (count % REPORT_INTERVAL == 0)
+                    log("Processed ${count} records")
             }
         }
         if (buffer.size() > 0) {
@@ -1289,10 +1300,11 @@ class ImportService {
             }
             buffer << doc
             count++
-            if (buffer.size() >= 1000) {
+            if (buffer.size() >= BUFFER_SIZE) {
                 indexService.indexBatch(buffer)
                 buffer.clear()
-                log("Processed ${count} records")
+                if (count % REPORT_INTERVAL == 0)
+                    log("Processed ${count} records")
             }
         }
         if (buffer.size() > 0) {
@@ -1317,10 +1329,11 @@ class ImportService {
             buildTaxonRecord(record, doc, attributionMap, datasetMap, taxonRanks, "inferredAccepted", defaultDatasetName)
             buffer << doc
             count++
-            if (buffer.size() >= 1000) {
+            if (buffer.size() >= BUFFER_SIZE) {
                 indexService.indexBatch(buffer)
                 buffer.clear()
-                log("Processed ${count} records")
+                if (count % REPORT_INTERVAL == 0)
+                    log("Processed ${count} records")
             }
         }
         if (buffer.size() > 0) {
@@ -1413,7 +1426,7 @@ class ImportService {
      * Go through the index and build link identifiers for unique names.
      */
     def buildLinkIdentifiers(online) {
-        int pageSize = 1000
+        int pageSize = BUFFER_SIZE
         int page = 0
         int added = 0
         def js = new JsonSlurper()
@@ -1479,13 +1492,14 @@ class ImportService {
      * Go through the index and build image links for taxa
      */
     def loadImages(online) {
-        int pageSize = 5000
+        int pageSize = BATCH_SIZE
         int processed = 0
         int added = 0
         def js = new JsonSlurper()
         def baseUrl = online ? grailsApplication.config.indexLiveBaseUrl : grailsApplication.config.indexOfflineBaseUrl
         def biocacheSolrUrl = grailsApplication.config.biocache.solr.url
-        def typeQuery = "idxtype:\"" + IndexDocType.TAXON.name() + "\"+AND+taxonomicStatus:accepted"
+        def acceptedQuery = TaxonomicType.values().findAll({ it.accepted }).collect({"taxonomicStatus:${it.term}"}).join('+OR+')
+        def typeQuery = "idxtype:\"${IndexDocType.TAXON.name()}\"+AND+($acceptedQuery)"
         def prevCursor = ""
         def cursor = "*"
         def listConfig = this.getConfigFile(grailsApplication.config.imagesListsUrl)
@@ -1529,7 +1543,6 @@ class ImportService {
                             if (!image) {
                                 def query = null
                                 query = addImageSearch(query, "lsid", taxonID, 100)
-                                query = addImageSearch(query, rank.nameField, name, 50)
                                 query = addImageSearch(query, rank.idField, taxonID, 20)
                                 if (query) {
                                     def taxonSearchUrl = biocacheSolrUrl + "/select?q=(${query}) AND multimedia:Image&${boosts}&rows=5&wt=json&fl=${imageFields}"
@@ -1762,8 +1775,8 @@ class ImportService {
      * @param online Use the online index
      */
     def denormaliseTaxa(online) {
-        int pageSize = 5000
-        int bufferLimit = 1000
+        int pageSize = BATCH_SIZE
+        int bufferLimit = BUFFER_SIZE
         int processed = 0
         def js = new JsonSlurper()
         def baseUrl = online ? grailsApplication.config.indexLiveBaseUrl : grailsApplication.config.indexOfflineBaseUrl
@@ -1848,7 +1861,7 @@ class ImportService {
                 processed++
                 if (!buffer.isEmpty())
                     indexService.indexBatch(buffer, online)
-                if (total > 0 && processed % 1000 == 0) {
+                if (total > 0 && processed % BUFFER_SIZE == 0) {
                     def percentage = Math.round(processed * 100 / total)
                     log("Denormalised ${processed} top-level taxa (${percentage}%)")
                 }
@@ -1884,7 +1897,7 @@ class ImportService {
                 processed++
                 if (!buffer.isEmpty())
                     indexService.indexBatch(buffer, online)
-                if (total > 0 && processed % 1000 == 0) {
+                if (total > 0 && processed % BUFFER_SIZE == 0) {
                     def percentage = Math.round(processed * 100 / total)
                     log("Denormalised ${processed} dangling taxa (${percentage}%)")
                 }
@@ -1930,7 +1943,7 @@ class ImportService {
                         indexService.indexBatch(buffer, online)
                         buffer.clear()
                     }
-                    if (total > 0 && processed % 1000 == 0) {
+                    if (total > 0 && processed % BUFFER_SIZE == 0) {
                         def percentage = Math.round(processed * 100 / total)
                         log("Denormalised ${processed} synonyms (${percentage}%)")
                     }

--- a/grails-app/services/au/org/ala/bie/IndexService.groovy
+++ b/grails-app/services/au/org/ala/bie/IndexService.groovy
@@ -192,9 +192,11 @@ class IndexService {
             query.highlightSimplePre = grailsApplication.config.solr.hl.simple.pre
             query.highlightSimplePost = grailsApplication.config.solr.hl.simple.post
         }
-        query.facet = facets.isEmpty()
-        query.facetMinCount = 1
-        query.facetFields = facets.toArray(new String[0])
+        if (facets) {
+            query.facet = true
+            query.facetMinCount = 1
+            facets.each { query.addFacetField(it) }
+        }
         if (start)
             query.start = start
         if (rows)

--- a/grails-app/services/au/org/ala/bie/LayerService.groovy
+++ b/grails-app/services/au/org/ala/bie/LayerService.groovy
@@ -1,0 +1,56 @@
+package au.org.ala.bie
+
+import au.org.ala.bie.util.Encoder
+import groovy.json.JsonSlurper
+
+import java.text.MessageFormat
+
+/**
+ * Interface to the spatial layers
+ */
+class LayerService {
+    def grailsApplication
+
+    /**
+     * Get a list of available layers
+     *
+     * @return The list of available layers
+     */
+    List layers() {
+        def url = Encoder.buildServiceUrl(grailsApplication.config.layers.service, grailsApplication.config.layers.layers)
+        def slurper = new JsonSlurper()
+        def json = slurper.parseText(url.getText('UTF-8'))
+        return json
+    }
+    /**
+     * Get the contents of a layer
+     *
+     * @param uid The layer UID
+     *
+     * @return The layer contents
+     */
+    def get(uid) {
+        def url = Encoder.buildServiceUrl(grailsApplication.config.layers.service, grailsApplication.config.layers.layer, uid)
+        def slurper = new JsonSlurper()
+        def json = slurper.parseText(url.getText('UTF-8'))
+        return json
+    }
+
+    /**
+     * Get the regions associated with a layer and place it into a temporary file.
+     *
+     * @param uid The layer UID
+     *
+     * @return The gzipped CSV file containing the layer information
+     */
+    File getRegions(uid) {
+        def tempFilePath = MessageFormat.format(grailsApplication.config.layers.temporaryFilePattern, uid)
+        def url = Encoder.buildServiceUrl(grailsApplication.config.layers.service,  grailsApplication.config.layers.objects, uid)
+        def file = new File(tempFilePath)
+        def stream = file.newOutputStream()
+        stream << url.openStream()
+        stream.flush()
+        stream.close()
+        return file
+    }
+}

--- a/grails-app/services/au/org/ala/bie/ListService.groovy
+++ b/grails-app/services/au/org/ala/bie/ListService.groovy
@@ -1,0 +1,32 @@
+package au.org.ala.bie
+
+import au.org.ala.bie.util.Encoder
+import groovy.json.JsonSlurper
+
+/**
+ * Interface to the list servers
+ */
+class ListService {
+    def grailsApplication
+
+    /**
+     * Get the contents of a list
+     *
+     * @param uid The list UID
+     * @param fields Additional fields to get from the list
+     */
+    def get(uid, List fields = []) {
+        def url = Encoder.buildServiceUrl(grailsApplication.config.lists.service, grailsApplication.config.lists.items, uid)
+        def slurper = new JsonSlurper()
+        def json = slurper.parseText(url.getText('UTF-8'))
+        return json.collect { item ->
+            def result = [lsid: item.lsid, name: item.name ]
+            fields.each { field ->
+                def value = field ? item.kvpValues.find { it.key == field }?.get("value") : null
+                if (value)
+                    result.put(field, value)
+            }
+            result
+        }
+    }
+}

--- a/grails-app/services/au/org/ala/bie/WordpressService.groovy
+++ b/grails-app/services/au/org/ala/bie/WordpressService.groovy
@@ -1,0 +1,66 @@
+package au.org.ala.bie
+
+import au.org.ala.bie.util.Encoder
+import groovy.json.JsonSlurper
+import org.apache.commons.lang.StringUtils
+import org.jsoup.Jsoup
+import org.jsoup.nodes.Document
+import org.jsoup.nodes.Element
+import org.jsoup.select.Elements
+
+/**
+ * Interface to the collectory
+ */
+class WordpressService {
+    def grailsApplication
+
+    /**
+     * Get a list of pages from the worpress system
+     *
+     * @return The list of available pages
+     */
+    def pages() {
+        def url = Encoder.buildServiceUrl(grailsApplication.config.wordPress.service, grailsApplication.config.wordPress.sitemap)
+        return crawlWordPressSite(url)
+    }
+
+    /**
+     * Read WP sitemap.xml file and return a list of page URLs
+     *
+     * @param url The site map url
+     * @return
+     */
+    private List crawlWordPressSite(URL url) throws Exception {
+        // get list of pages to crawl via Google sitemap xml file
+        // Note: sitemap.xml files can be nested, so code may need to read multiple files in the future (recursive function needed)
+        Document doc = Jsoup.connect(url.toExternalForm()).get()
+        Elements pages = doc.select("loc")
+        log.info("Sitemap file lists " + pages.size() + " pages.")
+        return pages.collect { it.text() }
+    }
+
+
+    /**
+     * Get the description of a page
+     *
+     * @param url The page url
+     *
+     * @return The a summary of the page contents
+     */
+    def get(String url) {
+        Document document = Jsoup.connect(url + grailsApplication.config.wordPress.contentOnlyParams).get()
+        def id = document.select("head > meta[name=id]").attr("content")
+        def shortlink = document.select("head > link[rel=shortlink]").attr("href")
+        if (StringUtils.isEmpty(id) && StringUtils.isNotBlank(shortlink)) {
+            // e.g. http://www.ala.org.au/?p=24241
+            id = StringUtils.split(shortlink, "=")[1];
+        }
+        return [
+                title: document.select("head > title").text(),
+                id: id,
+                shortlink: shortlink,
+                body: document.body().text(),
+                categories: document.select("ul[class=post-categories] li > a").collect { it.text() }
+        ]
+    }
+}

--- a/src/main/groovy/au/org/ala/bie/solr/SolrClientBean.groovy
+++ b/src/main/groovy/au/org/ala/bie/solr/SolrClientBean.groovy
@@ -1,0 +1,86 @@
+package au.org.ala.bie.solr
+
+import grails.util.CacheEntry
+import org.apache.solr.client.solrj.SolrClient
+import org.apache.solr.client.solrj.impl.CloudSolrClient
+import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient
+import org.apache.solr.client.solrj.impl.HttpSolrClient
+
+/**
+ * Delgatable solr client
+ * <p>
+ * The actual solr client is lazily onstructed from the client parameters.
+ * This allows easy
+ * </p>
+ *
+ * @author Doug Palmer &lt;Doug.Palmer@csiro.au&gt;
+ * @copyright Copyright &copy; 2018 Atlas of Living Australia
+ */
+class SolrClientBean {
+    /** The actual client. */
+    @Lazy
+    @Delegate
+    SolrClient client = { this.buildClient() }()
+    /** The client type */
+    ClientType clientType = ClientType.HTTP
+    /** The client connection string */
+    String connection = "http://localhost:8983"
+    /** The queue size for updatable clients */
+    int queueSize = 10
+    /** The number of threads for updatable clients */
+    int threadCount = 4
+
+    /**
+     * Default constructor
+     */
+    SolrClientBean() {
+    }
+
+    /**
+     * Construct with parameters
+     *
+     * @param clientType The client type
+     * @param connection The connection string
+     * @param queueSize The queue size
+     * @param threadCount The thread count
+     */
+    SolrClientBean(String clientType, String connection, int queueSize, int threadCount) {
+        this.clientType = clientType
+        this.connection = connection
+        this.queueSize = queueSize
+        this.threadCount = threadCount
+    }
+
+    /**
+     * Build the actual client
+     *
+     * @return
+     */
+    SolrClient buildClient() {
+        def builder
+        switch (clientType) {
+            case ClientType.UPDATE:
+                builder = new ConcurrentUpdateSolrClient.Builder(connection)
+                builder.withQueueSize(queueSize)
+                builder.withThreadCount(threadCount)
+                break;
+            case ClientType.ZOOKEEPER:
+                builder = new CloudSolrClient.Builder()
+                builder.withZkHost(connection)
+                break;
+            default:
+                builder = new HttpSolrClient.Builder(connection)
+        }
+        return builder.build()
+    }
+
+    void setClientType(String name) {
+       clientType = ClientType.valueOf(name)
+    }
+
+    enum ClientType {
+        HTTP,
+        UPDATE,
+        ZOOKEEPER
+    }
+}

--- a/src/main/groovy/au/org/ala/bie/util/ConservationListsSource.groovy
+++ b/src/main/groovy/au/org/ala/bie/util/ConservationListsSource.groovy
@@ -14,6 +14,7 @@ class ConservationListsSource {
     static log = LoggerFactory.getLogger(ConservationListsSource.class)
 
     def defaultSourceField = 'status'
+    def defaultKingdomField = 'kingdom'
     def lists = []
 
     /**
@@ -30,6 +31,7 @@ class ConservationListsSource {
             JsonSlurper slurper = new JsonSlurper()
             def config = slurper.parse(source)
             defaultSourceField = config?.defaultSourceField ?: 'status'
+            defaultKingdomField = config?.defaultKingdomField ?: 'kingdom'
             lists = config?.lists ?: []
             log.info("Loaded " + lists.size() + " lists")
         } catch (Exception ex) {

--- a/src/test/groovy/au/org/ala/bie/ListServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/bie/ListServiceSpec.groovy
@@ -1,0 +1,20 @@
+package au.org.ala.bie
+
+import grails.test.mixin.TestFor
+import spock.lang.Specification
+
+/**
+ * See the API for {@link grails.test.mixin.services.ServiceUnitTestMixin} for usage instructions
+ */
+@TestFor(ListService)
+class ListServiceSpec extends Specification {
+
+    def setup() {
+    }
+
+    def cleanup() {
+    }
+
+    void "test something"() {
+    }
+}

--- a/src/test/groovy/au/org/ala/bie/solr/SolrClientBeanSpec.groovy
+++ b/src/test/groovy/au/org/ala/bie/solr/SolrClientBeanSpec.groovy
@@ -1,0 +1,70 @@
+package au.org.ala.bie.solr
+
+import org.apache.solr.client.solrj.impl.CloudSolrClient
+import org.apache.solr.client.solrj.impl.ConcurrentUpdateSolrClient
+import org.apache.solr.client.solrj.impl.HttpSolrClient
+import spock.lang.Specification
+
+/**
+ * Test cases for {@link SolrClientBean}
+ *
+ * @author Doug Palmer &lt;Doug.Palmer@csiro.au&gt;
+ * @copyright Copyright &copy; 2018 Atlas of Living Australia
+ */
+class SolrClientBeanSpec extends Specification {
+    def "create http client"() {
+        given:
+        def bean = new SolrClientBean()
+        bean.clientType = 'HTTP'
+        bean.connection = 'http://localhost:10228'
+
+        when:
+        def client = bean.client
+
+        then:
+            client != null
+            client instanceof HttpSolrClient
+    }
+
+    def "create update client"() {
+        given:
+        def bean = new SolrClientBean()
+        bean.clientType = 'UPDATE'
+        bean.connection = 'http://localhost:10228'
+        bean.queueSize = 4
+        bean.threadCount = 10
+
+        when:
+        def client = bean.client
+
+        then:
+        client != null
+        client instanceof ConcurrentUpdateSolrClient
+    }
+
+    def "create zookeeper client"() {
+        given:
+        def bean = new SolrClientBean()
+        bean.clientType = 'ZOOKEEPER'
+        bean.connection = 'localhost:10228'
+
+        when:
+        def client = bean.client
+
+        then:
+        client != null
+        client instanceof CloudSolrClient
+    }
+
+    def "test delegation"() {
+        given:
+        def bean = new SolrClientBean()
+        bean.clientType = 'HTTP'
+        bean.connection = 'http://localhost:10228'
+        when:
+        def binder = bean.binder
+        then:
+        binder != null
+    }
+
+}


### PR DESCRIPTION
This originally started out as a fix to https://github.com/AtlasOfLivingAustralia/bie-index/issues/199 and kept going. One of the big things was to allow image and occurrence searches to go via biocache-service and make use of the reliability of the services, rather than hit the biocache solr instance and make it unstable.

* Fix for Issue 199
* Move to solr 6.6.5 in line with other solr instances
* Use solr4j library to make requests
* Species lists, biocache, wordpress etc. factored out into services. Test cases for these in the future.
* Allow connections to solr cloud/zookeeper instances
* Reworking of configuration yml to group similar things together

The downsides:

* Configuration is now going to have to be in YAML, since the are too many odd bits and pieces that need lists and the like.
* The new solr schema needs updating, as does the ala-install scripts. Basically, scrap everything and start again.