### PR TITLE
Update admin plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,10 +116,10 @@ In addition to indexing the content of the darwin core archive, the ingestion & 
 
 This application makes use of the following technologies
 
-- Apache SOLR 4.10.x
-- Grails 2.4.x
+- Apache SOLR 6.6.x
+- Grails 3.2.x
 - Tomcat 7 or higher
-- Java 7 or higher
+- Java 8 or higher
 
 ![Architecture image](architecture.jpg)
 

--- a/build.gradle
+++ b/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     compile(group: 'org.grails.plugins', name: 'ala-auth', version:'3.1.0') {
         exclude group: 'javax.servlet', module: 'servlet-api'
     }
-    compile group: 'org.grails.plugins', name: 'ala-admin-plugin', version: '2.0'
+    compile group: 'org.grails.plugins', name: 'ala-admin-plugin', version: '2.1'
     compile "org.grails.plugins:grails-spring-websocket:2.3.0"
     compile 'org.webjars:swagger-ui:3.18.2'
     //compile "org.grails.plugins:rxjava2:2.0.0"

--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -205,10 +205,6 @@ solr:
       threadCount: 4
     search:
       qf:
-        - scientificName^1000
-        - commonName^500
-        - exact_text^200
-        - doc_name^100
         - text
       bq:
       fq:

--- a/grails-app/services/au/org/ala/bie/ImportService.groovy
+++ b/grails-app/services/au/org/ala/bie/ImportService.groovy
@@ -2028,6 +2028,7 @@ class ImportService implements GrailsConfigurationAware {
         int bufferLimit = BUFFER_SIZE
         int pages = 0
         int processed = 0
+        int lastReported = 0
         def js = new JsonSlurper()
         def prevCursor = ""
         def cursor = CursorMarkParams.CURSOR_MARK_START
@@ -2067,7 +2068,8 @@ class ImportService implements GrailsConfigurationAware {
                 }
                 if (!buffer.isEmpty())
                     indexService.indexBatch(buffer, online)
-                if (total > 0) {
+                if (total > 0 && (processed - lastReported) >= REPORT_INTERVAL) {
+                    lastReported = processed
                     def percentage = Math.round((processed / total) * 100 )
                     log("Weighted ${processed} items (${percentage}%)")
                 }

--- a/grails-app/services/au/org/ala/bie/SearchService.groovy
+++ b/grails-app/services/au/org/ala/bie/SearchService.groovy
@@ -833,17 +833,19 @@ class SearchService {
 
         //get parents
         def parentGuid = taxon.parentGuid
+        def seen = [] as Set
         def stop = false
 
         while(parentGuid && !stop){
             taxon = retrieveTaxon(parentGuid)
-            if(taxon) {
+            if(taxon && !seen.contains(taxon.guid)) {
                 classification.add(0, [
                         rank : taxon.rank,
                         rankID : taxon.rankID,
                         scientificName : taxon.scientificName,
                         guid : taxon.guid
                 ])
+                seen.add(taxon.guid)
                 parentGuid = taxon.parentGuid
             } else {
                 stop = true


### PR DESCRIPTION
Just use text for query fields, since the weighting does a better job of boosting queries.
Cut report verbosity down on weighting
Cut loops in higher taxon lookup during classification.