### PR TITLE
Properly crawl wordpress sitemap.xml

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -148,6 +148,12 @@ wordPress:
   service: https://www.ala.org.au
   sitemap: /sitemap.xml
   page: /?page_id={0}
+  timeout: 10000
+  validateTLS: false
+  titleSelector: head > title
+  contentSelector: body main
+  idSelector: head > meta[name=id]
+  shortLinkSelector: head > link[rel=shortlink]
   excludedCategories:
   - button
   contentOnlyParams: ?content-only=1&categories=1

--- a/src/test/groovy/au/org/ala/bie/WordPressServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/bie/WordPressServiceSpec.groovy
@@ -32,6 +32,7 @@ class WordPressServiceSpec extends Specification {
 
     def setupSpec() {
         // call web service once only and store results in static vars
+        service.setConfiguration(grailsApplication.config)
         pages = service.resources("")
         firstPageUrl = pages.get(1) // homepage has no body so use second page for testing
         firstPageMap = service.getResource(firstPageUrl)


### PR DESCRIPTION
* Follow sub-sitemaps from sitemap.xml
* Avoid the surrounding content on the site by looking for the <main> element that contains content