### PR TITLE
Issue 297

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -189,7 +189,7 @@ vernacularListsUrl: /default-vernacular-lists.json
 # Location of locality keywords (null for default)
 localityKeywordsUrl: /default-locality-keywords.json
 #nationalSpeciesDatasets: dr2699,dr2700,dr2702,dr2704,dr2703,dr3118
-defaultDownloadFields: guid,rank,scientificName,scientificNameAuthorship,taxonomicStatus,establishmentMeans,rk_genus,rk_family,rk_order,rk_class,rk_phylum,rk_kingdom,datasetName,parentGuid,acceptedConceptName,acceptedConceptID
+defaultDownloadFields: guid,rank,scientificName,scientificNameAuthorship,taxonomicStatus,establishmentMeans,rk_genus,rk_family,rk_order,rk_class,rk_phylum,rk_kingdom,datasetName,parentGuid,acceptedConceptName,acceptedConceptID,idxtype,name
 additionalResultFields: ""
 #toggle for the population of occurrence counts
 

--- a/grails-app/controllers/au/org/ala/bie/ImportController.groovy
+++ b/grails-app/controllers/au/org/ala/bie/ImportController.groovy
@@ -15,7 +15,6 @@ package au.org.ala.bie
 
 import au.org.ala.bie.util.Job
 import grails.converters.JSON
-import org.apache.commons.lang.BooleanUtils
 import au.org.ala.web.AlaSecured
 /**
  * Controller for data import into the system.
@@ -70,7 +69,7 @@ class ImportController {
             return
         }
 
-        def clearIndex = BooleanUtils.toBooleanObject(params.clear_index ?: "false")
+        def clearIndex = params.getBoolean('clear_index', false)
         def dwcDir = params.dwca_dir
 
         if(new File(dwcDir).exists()){
@@ -212,7 +211,8 @@ class ImportController {
      */
     // Documented in openapi.yml
     def importOccurrences(){
-        def job = execute("importOccurrences", "admin.button.loadoccurrence", { importService.importOccurrenceData() })
+        def online = params.getBoolean('online', false)
+        def job = execute("importOccurrences", "admin.button.loadoccurrence", { importService.importOccurrenceData(online) })
         asJson (job.status())
 
     }
@@ -242,7 +242,7 @@ class ImportController {
 
     // Documented in openapi.yml
     def buildLinkIdentifiers() {
-        def online = BooleanUtils.toBooleanObject(params.online ?: "false")
+        def online = params.getBoolean('online', false)
         def job = execute("buildLinkIdentifiers", "admin.button.buildLinks", { importService.buildLinkIdentifiers(online) })
         asJson (job.status())
 
@@ -250,7 +250,7 @@ class ImportController {
 
     // Documented in openapi.yml
     def denormaliseTaxa() {
-        def online = BooleanUtils.toBooleanObject(params.online ?: "false")
+        def online = params.getBoolean('online', false)
         def job = execute("denormaliseTaxa", "admin.button.denormalise", { importService.denormaliseTaxa(online) })
         asJson (job.status())
 
@@ -258,7 +258,7 @@ class ImportController {
 
     // Documented in openapi.yml
     def buildFavourites() {
-        def online = BooleanUtils.toBooleanObject(params.online ?: "false")
+        def online = params.getBoolean('online', false)
         def job = execute("buildFavourites", "admin.button.buildfavourites", { importService.buildFavourites(online) })
         asJson (job.status())
 
@@ -266,7 +266,7 @@ class ImportController {
 
     // Documented in openapi.yml
     def buildWeights() {
-        def online = BooleanUtils.toBooleanObject(params.online ?: "false")
+        def online = params.getBoolean('online', false)
         def job = execute("buildWeights", "admin.button.buildweights", { importService.buildWeights(online) })
         asJson (job.status())
 
@@ -274,7 +274,7 @@ class ImportController {
 
     // Documented in openapi.yml
     def buildSuggestIndex() {
-        def online = BooleanUtils.toBooleanObject(params.online ?: "false")
+        def online = params.getBoolean('online', false)
         def job = execute("buildSuggestIndex", "admin.button.buildsuggestindex", { importService.buildSuggestIndex(online) })
         asJson (job.status())
 
@@ -288,14 +288,14 @@ class ImportController {
      */
     // Documented in openapi.yml
     def loadPreferredImages() {
-        def online = BooleanUtils.toBooleanObject(params.online ?: "false")
+        def online = params.getBoolean('online', false)
         def job = execute("loadImages", "admin.button.loadimagespref", { importService.loadPreferredImages(online) })
         asJson (job.status())
     }
 
     // Documented in openapi.yml
     def loadImages() {
-        def online = BooleanUtils.toBooleanObject(params.online ?: "false")
+        def online = params.getBoolean('online', false)
         def job = execute("loadImages", "admin.button.loadimagesall", { importService.loadImages(online) })
         asJson (job.status())
     }

--- a/grails-app/i18n/messages.properties
+++ b/grails-app/i18n/messages.properties
@@ -82,6 +82,8 @@ download.rk_phylum=phylum
 download.rk_subkingdom=subkingdom
 download.rk_kingdom=kingdom
 download.datasetName=datasetName
+download.idxtype=type
+download.name=title
 
 admin.ala.label=ALA admin functions
 admin.ala.lead=view config, build info &amp; set banner message

--- a/grails-app/services/au/org/ala/bie/DownloadService.groovy
+++ b/grails-app/services/au/org/ala/bie/DownloadService.groovy
@@ -31,7 +31,7 @@ class DownloadService {
     def download(params, OutputStream outputStream, Locale locale){
         def q = Encoder.escapeQuery(params.q ?: "*:*")
         def fq = new ArrayList<>(params.list('fq')) // Make modifiable
-        def fields = params.fields ?: grailsApplication.config.defaultDownloadFields
+        def fields = params.fields ?: grailsApplication.getRequiredProperty('defaultDownloadFields')
         def fqs = ''
 
         grailsApplication.config.solr.search.fq.each { fq << it }

--- a/grails-app/services/au/org/ala/bie/DownloadService.groovy
+++ b/grails-app/services/au/org/ala/bie/DownloadService.groovy
@@ -13,13 +13,11 @@
 
 package au.org.ala.bie
 
-import au.org.ala.bie.search.IndexDocType
 import au.org.ala.bie.util.Encoder
 
 class DownloadService {
 
     def grailsApplication
-    def indexService
     def messageSource
 
     /**

--- a/grails-app/services/au/org/ala/bie/DownloadService.groovy
+++ b/grails-app/services/au/org/ala/bie/DownloadService.groovy
@@ -13,6 +13,7 @@
 
 package au.org.ala.bie
 
+import au.org.ala.bie.search.IndexDocType
 import au.org.ala.bie.util.Encoder
 
 class DownloadService {
@@ -31,10 +32,11 @@ class DownloadService {
      */
     def download(params, OutputStream outputStream, Locale locale){
         def q = Encoder.escapeQuery(params.q ?: "*:*")
-        def fq = params.list('fq')
-        def fields = params.fields ?: grailsApplication.config.defaultDownloadFields ?: "guid,rank,scientificName,rk_genus,rk_family,rk_order,rk_class,rk_phylum,rk_kingdom,datasetName"
+        def fq = new ArrayList<>(params.list('fq')) // Make modifiable
+        def fields = params.fields ?: grailsApplication.config.defaultDownloadFields
         def fqs = ''
 
+        grailsApplication.config.solr.search.fq.each { fq << it }
         if (fq) {
             fqs = '&fq=' + fq.collect({ Encoder.escapeQuery(it) }).join("&fq=")
         }


### PR DESCRIPTION
Don't download things you don't see in the search. This uses the same implicit filters (no taxon variant or identifier records) that are injected into the search.
Include record type and name in download results for data resources, regions, etc.
Simplify the occurrence count scan to avoid stressing the biocache and, paradoxically, speed things up.