### PR TITLE
Improve wordpress crawl

### DIFF
--- a/grails-app/conf/application.yml
+++ b/grails-app/conf/application.yml
@@ -146,7 +146,8 @@ images:
   index: true
 wordPress:
   service: https://www.ala.org.au
-  sitemap: /sitemap.xml
+  sitemap: /xmlsitemap.xml
+  index: index.xml
   page: /?page_id={0}
   timeout: 10000
   validateTLS: false
@@ -154,6 +155,8 @@ wordPress:
   contentSelector: body main
   idSelector: head > meta[name=id]
   shortLinkSelector: head > link[rel=shortlink]
+  excludedLocations:
+  - .*/category/.*
   excludedCategories:
   - button
   contentOnlyParams: ?content-only=1&categories=1

--- a/src/test/groovy/au/org/ala/bie/WordPressServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/bie/WordPressServiceSpec.groovy
@@ -33,6 +33,7 @@ class WordPressServiceSpec extends Specification {
     def setupSpec() {
         // call web service once only and store results in static vars
         service.setConfiguration(grailsApplication.config)
+        service.sitemap = '/sitemap.xml' // Depends on wordpress implementation!
         pages = service.resources("")
         firstPageUrl = pages.get(1) // homepage has no body so use second page for testing
         firstPageMap = service.getResource(firstPageUrl)


### PR DESCRIPTION
Fix for #311

Ensure wordpress can retrieve sub sitemaps in the face of 403s if a filename is not supplied.
Filter out category URLs