### PR TITLE
Hotfix for child classification issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ branches:
   only:
   - master
   - develop
+  - hotfix
   - 1.4.2.1
 before_cache:
   - rm -f  $HOME/.gradle/caches/modules-2/modules-2.lock

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     }
 }
 
-version "1.4.13"
+version "1.4.13.1"
 group "au.org.ala"
 
 apply plugin:"eclipse"


### PR DESCRIPTION
See #321

This fix comes from the develop branch. Rather than attempt to update everything, which will include a new version of solr and new name matching library, add a single point change to fix the childConcepts call and ensure that rankless taxa are included.

Needed by galah.