### PR TITLE
Fix admin index page

### DIFF
--- a/grails-app/views/admin/index.gsp
+++ b/grails-app/views/admin/index.gsp
@@ -39,12 +39,11 @@
         </tr>
         </thead>
         <tbody>
-        <tr>
-            <td>bie</td><td>${info.response.status.bie.index.numDocs}</td><td>${info.response.status.bie.index.version}</td><td>${info.response.status.bie.instanceDir}</td>
-        </tr>
-        <tr>
-            <td>bie-offline</td><td>${info.response.status['bie-offline'].index.numDocs}</td><td>${info.response.status['bie-offline'].index.version}</td><td>${info.response.status['bie-offline'].instanceDir}</td>
-        </tr>
+        <g:each in="${info.response.status}" var="core" >
+           <tr>
+               <td>${core.key}</td><td>${core.value.index.numDocs}</td><td>${core.value.index.version}</td><td>${core.value.instanceDir}</td>
+           </tr>
+        </g:each>
         </tbody>
     </table>
 </div>

--- a/grails-app/views/import/all.gsp
+++ b/grails-app/views/import/all.gsp
@@ -43,12 +43,11 @@
                 </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td>bie</td><td>${info.response.status.bie.index.numDocs}</td><td>${info.response.status.bie.index.version}</td><td>${info.response.status.bie.instanceDir}</td>
-                </tr>
-                <tr>
-                    <td>bie-offline</td><td>${info.response.status['bie-offline'].index.numDocs}</td><td>${info.response.status['bie-offline'].index.version}</td><td>${info.response.status['bie-offline'].instanceDir}</td>
-                </tr>
+            <g:each in="${info.response.status}" var="core" >
+               <tr>
+                   <td>${core.key}</td><td>${core.value.index.numDocs}</td><td>${core.value.index.version}</td><td>${core.value.instanceDir}</td>
+               </tr>
+            </g:each>
             </tbody>
         </table>
     </div>


### PR DESCRIPTION
The admin page was broken on our deployment. (500 internal server error cause by a null-pointer reference)
This was caused by our SOLR not using the default core names: _bie_ and _bie-offline_.

We are running SOLR 8 in "cloud" mode.
That seems to make the collections use strange core name like _bie_shard1_replica_n1_, etc.

Instead of expecting very specific core names to be present in the status call.
This change instead remove all expectations for names and simply loops over all cores returned in the status.

So this does alter the behavior, as now all cores will show up.
But it is safer, because not having a _bie_ or _bie-offline_ core will not prevent the page from loading.