### PR TITLE
Add WebUtils for consistent User-Agent handling in outbound requests

### DIFF
--- a/grails-app/services/au/org/ala/bie/BieAuthService.groovy
+++ b/grails-app/services/au/org/ala/bie/BieAuthService.groovy
@@ -1,6 +1,7 @@
 package au.org.ala.bie
 
 import au.org.ala.bie.util.Encoder
+import au.org.ala.bie.util.WebUtils
 import grails.converters.JSON
 
 class BieAuthService {
@@ -10,7 +11,7 @@ class BieAuthService {
     def checkApiKey(key) {
         // try the preferred api key store first
         def url = grailsApplication.config.security.apikey.serviceUrl + Encoder.escapeQuery(key)
-        def conn = new URL(url).openConnection()
+        def conn = WebUtils.withUserAgent(new URL(url).openConnection())
         if (conn.getResponseCode() == 200) {
             String resp = conn.content.text as String
             return JSON.parse(resp)

--- a/grails-app/services/au/org/ala/bie/BiocacheService.groovy
+++ b/grails-app/services/au/org/ala/bie/BiocacheService.groovy
@@ -2,6 +2,7 @@ package au.org.ala.bie
 
 
 import au.org.ala.bie.util.Encoder
+import au.org.ala.bie.util.WebUtils
 import groovy.json.JsonSlurper
 
 /**
@@ -45,6 +46,7 @@ class BiocacheService {
             conn.setDoOutput(false)
             conn.setRequestProperty("Content-Type", "application/x-www-form-urlencoded");
             conn.setRequestProperty("Accept-Charset", ENCODING);
+            conn.setRequestProperty("User-Agent", WebUtils.userAgent());
             return slurper.parse(conn.inputStream, ENCODING)
         } catch (SocketTimeoutException e) {
             log.error("Timed out calling web service. URL= ${url}.", e)
@@ -86,7 +88,7 @@ class BiocacheService {
             query << "dir=${Encoder.escapeQuery(dir)}"
         }
         def url = grailsApplication.config.biocache.service + grailsApplication.config.biocache.search + '?' + query.join('&')
-        def response = url.toURL().getText("UTF-8")
+        def response = url.toURL().getText(WebUtils.connectionParams, "UTF-8")
         return slurper.parseText(response)
     }
 }

--- a/grails-app/services/au/org/ala/bie/BiocollectService.groovy
+++ b/grails-app/services/au/org/ala/bie/BiocollectService.groovy
@@ -13,6 +13,7 @@
 
 package au.org.ala.bie
 
+import au.org.ala.bie.util.WebUtils
 import grails.converters.JSON
 
 /**
@@ -40,7 +41,7 @@ class BiocollectService {
             def url = new URL(baseUrl + "&max=" + max + "&offset=" + offset)
             offset += max
 
-            def newProjects = JSON.parse(url.getText('UTF-8')).projects
+            def newProjects = JSON.parse(url.getText(WebUtils.connectionParams, 'UTF-8')).projects
             hasMore = newProjects.size() == max
 
             projects.addAll(newProjects)

--- a/grails-app/services/au/org/ala/bie/CollectoryService.groovy
+++ b/grails-app/services/au/org/ala/bie/CollectoryService.groovy
@@ -1,6 +1,7 @@
 package au.org.ala.bie
 
 import au.org.ala.bie.util.Encoder
+import au.org.ala.bie.util.WebUtils
 import grails.converters.JSON
 import groovy.json.JsonSlurper
 
@@ -22,7 +23,7 @@ class CollectoryService {
     def resources(String type) {
         def url = Encoder.buildServiceUrl(grailsApplication.config.collectory.service, grailsApplication.config.collectory.resources, type)
         def slurper = new JsonSlurper()
-        def json = slurper.parseText(url.getText('UTF-8'))
+        def json = slurper.parseText(url.getText(WebUtils.connectionParams, 'UTF-8'))
         return json
     }
 
@@ -35,7 +36,7 @@ class CollectoryService {
      */
     def get(url) {
         def slurper = new JsonSlurper()
-        def json = slurper.parseText(url.toURL().getText('UTF-8'))
+        def json = slurper.parseText(url.toURL().getText(WebUtils.connectionParams, 'UTF-8'))
         return json
     }
 
@@ -49,6 +50,7 @@ class CollectoryService {
                 conn.setRequestMethod("POST")
                 conn.setRequestProperty("Content-Type", "application/json")
                 conn.setRequestProperty("Content-Length", String.valueOf(bytes.length))
+                conn.setRequestProperty("User-Agent", WebUtils.userAgent())
                 conn.setDoOutput(true)
                 conn.getOutputStream().write(bytes)
 

--- a/grails-app/services/au/org/ala/bie/DownloadService.groovy
+++ b/grails-app/services/au/org/ala/bie/DownloadService.groovy
@@ -16,6 +16,7 @@ package au.org.ala.bie
 import au.com.bytecode.opencsv.CSVReader
 import au.com.bytecode.opencsv.CSVWriter
 import au.org.ala.bie.util.Encoder
+import au.org.ala.bie.util.WebUtils
 
 class DownloadService {
 
@@ -55,7 +56,7 @@ class DownloadService {
                 Encoder.escapeQuery(fields) + "&csv.header=false&rows=" + grailsApplication.config.downloadMaxRows +
                 "&q=${q}${fqs}"
 
-        def connection = new URL(queryUrl).openConnection()
+        def connection = WebUtils.withUserAgent(new URL(queryUrl).openConnection())
         CSVReader csv = new CSVReader(new InputStreamReader(connection.getInputStream()))
         String [][] all = csv.readAll()
 

--- a/grails-app/services/au/org/ala/bie/ImportService.groovy
+++ b/grails-app/services/au/org/ala/bie/ImportService.groovy
@@ -19,6 +19,7 @@ import au.org.ala.bie.indexing.WeightBuilder
 import au.org.ala.bie.search.IndexDocType
 import au.org.ala.bie.util.Encoder
 import au.org.ala.bie.util.TitleCapitaliser
+import au.org.ala.bie.util.WebUtils
 import au.org.ala.names.model.ALAParsedName
 import au.org.ala.names.model.RankType
 import au.org.ala.names.model.TaxonomicType
@@ -3274,7 +3275,7 @@ class ImportService implements GrailsConfigurationAware {
      */
     private String getStringForUrl(URL url) throws IOException {
         String output = ""
-        def inStm = url.openStream()
+        def inStm = WebUtils.withUserAgent(url.openConnection()).getInputStream()
         try {
             output = IOUtils.toString(inStm)
         } finally {
@@ -3323,9 +3324,11 @@ class ImportService implements GrailsConfigurationAware {
     private getConfigFile(String url) {
         //url = URLEncoder.encode(url, "UTF-8")
         URL source = this.class.getResource(url)
-        if (source == null)
-            source = new URL(url)
         JsonSlurper slurper = new JsonSlurper()
+        if (source == null) {
+            // remote URL - identify ourselves with an application User-Agent
+            return slurper.parse(new URL(url), WebUtils.connectionParams)
+        }
         return slurper.parse(source)
      }
 

--- a/grails-app/services/au/org/ala/bie/KnowledgeBaseService.groovy
+++ b/grails-app/services/au/org/ala/bie/KnowledgeBaseService.groovy
@@ -15,6 +15,7 @@ package au.org.ala.bie
 
 import au.org.ala.bie.indexing.IndexingInterface
 import au.org.ala.bie.util.Encoder
+import au.org.ala.bie.util.WebUtils
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import org.jsoup.nodes.Element
@@ -60,7 +61,7 @@ class KnowledgeBaseService implements IndexingInterface {
         String baseUrl = grailsApplication.config.getProperty('knowledgeBase.service')
         String sectionCssSelector = grailsApplication.config.getProperty('knowledgeBase.sectionSelector')
         // do the first level scraping
-        Document doc = Jsoup.connect("${url}").timeout(10000).get()
+        Document doc = Jsoup.connect("${url}").userAgent(WebUtils.userAgent()).timeout(10000).get()
         Elements sections = doc.select(sectionCssSelector) // link to sections
 
         if (sections.size() > 0) {
@@ -71,7 +72,7 @@ class KnowledgeBaseService implements IndexingInterface {
 
                 if (pageUrl) {
                     // do the second level scraping
-                    Document sectionDoc = Jsoup.connect(baseUrl + pageUrl).timeout(10000).get()
+                    Document sectionDoc = Jsoup.connect(baseUrl + pageUrl).userAgent(WebUtils.userAgent()).timeout(10000).get()
                     String articleCssSelector = grailsApplication.config.getProperty('knowledgeBase.articleCssSelector')
                     Elements articles = sectionDoc.select(articleCssSelector) // link to KB pages
 
@@ -118,7 +119,7 @@ class KnowledgeBaseService implements IndexingInterface {
      */
     Map getResource(String url) throws IOException {
         Map doc = [:]
-        Document page = Jsoup.connect(url).timeout(10000).get()
+        Document page = Jsoup.connect(url).userAgent(WebUtils.userAgent()).timeout(10000).get()
 
         if (page) {
             doc["id"] = page.select("p.article-vote").attr("data-article-id")

--- a/grails-app/services/au/org/ala/bie/LayerService.groovy
+++ b/grails-app/services/au/org/ala/bie/LayerService.groovy
@@ -1,6 +1,7 @@
 package au.org.ala.bie
 
 import au.org.ala.bie.util.Encoder
+import au.org.ala.bie.util.WebUtils
 import groovy.json.JsonSlurper
 
 import java.text.MessageFormat
@@ -19,7 +20,7 @@ class LayerService {
     List layers() {
         def url = Encoder.buildServiceUrl(grailsApplication.config.layers.service, grailsApplication.config.layers.layers)
         def slurper = new JsonSlurper()
-        def json = slurper.parseText(url.getText('UTF-8'))
+        def json = slurper.parseText(url.getText(WebUtils.connectionParams, 'UTF-8'))
         return json
     }
     /**
@@ -32,7 +33,7 @@ class LayerService {
     def get(uid) {
         def url = Encoder.buildServiceUrl(grailsApplication.config.layers.service, grailsApplication.config.layers.layer, uid)
         def slurper = new JsonSlurper()
-        def json = slurper.parseText(url.getText('UTF-8'))
+        def json = slurper.parseText(url.getText(WebUtils.connectionParams, 'UTF-8'))
         return json
     }
 
@@ -48,7 +49,7 @@ class LayerService {
         def url = Encoder.buildServiceUrl(grailsApplication.config.layers.service,  grailsApplication.config.layers.objects, uid)
         def file = new File(tempFilePath)
         def stream = file.newOutputStream()
-        stream << url.openStream()
+        stream << WebUtils.withUserAgent(url.openConnection()).getInputStream()
         stream.flush()
         stream.close()
         return file

--- a/grails-app/services/au/org/ala/bie/ListService.groovy
+++ b/grails-app/services/au/org/ala/bie/ListService.groovy
@@ -1,6 +1,7 @@
 package au.org.ala.bie
 
 import au.org.ala.bie.util.Encoder
+import au.org.ala.bie.util.WebUtils
 import groovy.json.JsonSlurper
 import org.apache.http.entity.ContentType
 import grails.converters.JSON
@@ -289,11 +290,7 @@ mutation add {
         try {
             URL urlObj = url instanceof URL ? url : new URL(url.toString())
             def connection = urlObj.openConnection()
-            def appName = grailsApplication.config.getProperty('info.app.name', String, 'bie-index')
-            def appVersion = grailsApplication.config.getProperty('info.app.version', String, '3.1')
-            log.debug("app.name: ${appName} | app.version: ${appVersion}")
-
-            connection.setRequestProperty("User-Agent", "${appName}/${appVersion}")
+            connection.setRequestProperty("User-Agent", WebUtils.userAgent())
             connection.setConnectTimeout(10000) // 10 seconds
             connection.setReadTimeout(30000)    // 30 seconds
 
@@ -317,10 +314,6 @@ mutation add {
     }
 
     Map getUserAgentHeader() {
-        def appName = grailsApplication.config.getProperty('info.app.name', String, 'bie-index')
-        def appVersion = grailsApplication.config.getProperty('info.app.version', String, '3.1')
-        log.debug("app.name: ${appName} | app.version: ${appVersion}")
-        String value = "${appName}/${appVersion}" as String
-        return ["User-Agent": value]
+        return WebUtils.userAgentHeader()
     }
 }

--- a/grails-app/services/au/org/ala/bie/NameService.groovy
+++ b/grails-app/services/au/org/ala/bie/NameService.groovy
@@ -15,6 +15,7 @@
 package au.org.ala.bie
 
 import au.org.ala.bie.util.Encoder
+import au.org.ala.bie.util.WebUtils
 import grails.config.Config
 import grails.converters.JSON
 import grails.core.support.GrailsConfigurationAware
@@ -72,7 +73,7 @@ class NameService implements GrailsConfigurationAware {
         }
         def url = new URL(this.service + "/api/searchByClassification?" + query)
         def slurper = new JsonSlurper()
-        def json = slurper.parseText(url.getText('UTF-8'))
+        def json = slurper.parseText(url.getText(WebUtils.connectionParams, 'UTF-8'))
         if (!json.success)
             return null
         def matchType = json.matchType
@@ -92,6 +93,7 @@ class NameService implements GrailsConfigurationAware {
             conn.setRequestMethod("POST")
             conn.setRequestProperty("Content-Type", "application/json")
             conn.setRequestProperty("Content-Length", String.valueOf(bytes.length))
+            conn.setRequestProperty("User-Agent", WebUtils.userAgent())
             conn.setDoOutput(true)
             conn.getOutputStream().write(bytes)
 

--- a/grails-app/services/au/org/ala/bie/WordpressService.groovy
+++ b/grails-app/services/au/org/ala/bie/WordpressService.groovy
@@ -15,6 +15,7 @@ package au.org.ala.bie
 
 import au.org.ala.bie.indexing.IndexingInterface
 import au.org.ala.bie.util.Encoder
+import au.org.ala.bie.util.WebUtils
 import grails.config.Config
 import grails.core.support.GrailsConfigurationAware
 import org.apache.commons.lang.StringUtils
@@ -87,7 +88,7 @@ class WordpressService implements IndexingInterface, GrailsConfigurationAware {
                 continue
             seen << source
             try {
-                Document doc = Jsoup.connect(source.toExternalForm()).timeout(this.timeout).get()
+                Document doc = Jsoup.connect(source.toExternalForm()).userAgent(WebUtils.userAgent()).timeout(this.timeout).get()
                 Elements sitemaps = doc.select("sitemapindex sitemap loc")
                 sitemaps.each { loc ->
                     try {
@@ -128,7 +129,7 @@ class WordpressService implements IndexingInterface, GrailsConfigurationAware {
     Map getResource(String url) {
         String fullUrl = url + contentOnlyParams
         log.info "GETing url: ${fullUrl}"
-        Document document = Jsoup.connect(fullUrl).timeout(this.timeout).get()
+        Document document = Jsoup.connect(fullUrl).userAgent(WebUtils.userAgent()).timeout(this.timeout).get()
 
         // some summary/landing pages do not work with `content-only=1`, so we don't want to index them
         if (document.select("body.ala-content") || !document.body().text()) {

--- a/src/main/groovy/au/org/ala/bie/util/ConservationListsSource.groovy
+++ b/src/main/groovy/au/org/ala/bie/util/ConservationListsSource.groovy
@@ -30,11 +30,13 @@ class ConservationListsSource {
     ConservationListsSource(String url) {
         try {
             URL source = this.class.getResource(url)
-            if (!source)
+            boolean remote = !source
+            if (remote)
                 source = new URL(url)
             log.info("Loading conservation lists from ${url} -> ${source}")
             JsonSlurper slurper = new JsonSlurper()
-            def config = slurper.parse(source)
+            // identify ourselves with an application User-Agent for remote loads
+            def config = remote ? slurper.parse(source, WebUtils.connectionParams) : slurper.parse(source)
             defaultSourceField = config?.defaultSourceField ?: 'status'
             defaultKingdomField = config?.defaultKingdomField ?: 'kingdom'
             defaultPhylumField = config?.defaultPhylumField ?: 'phylum'

--- a/src/main/groovy/au/org/ala/bie/util/WebUtils.groovy
+++ b/src/main/groovy/au/org/ala/bie/util/WebUtils.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2025 Atlas of Living Australia
+ * All Rights Reserved.
+ * The contents of this file are subject to the Mozilla Public
+ * License Version 1.1 (the "License"); you may not use this file
+ * except in compliance with the License. You may obtain a copy of
+ * the License at http://www.mozilla.org/MPL/
+ * Software distributed under the License is distributed on an "AS
+ * IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing
+ * rights and limitations under the License.
+ */
+package au.org.ala.bie.util
+
+import grails.util.Holders
+import groovy.util.logging.Slf4j
+
+/**
+ * Utilities for outbound HTTP requests.
+ * <p>
+ * Provides a single source for the application User-Agent so that requests to
+ * downstream services (biocache-ws, namematching-ws, collectory, etc.) are
+ * identified as "&lt;app name&gt;/&lt;app version&gt;" rather than the JVM default
+ * (e.g. "Java/11.0.31").
+ */
+@Slf4j
+class WebUtils {
+    /** Fallbacks used when the build-populated info.app.* config is unavailable (e.g. in unit tests). */
+    static final String DEFAULT_APP_NAME = 'bie-index'
+    static final String DEFAULT_APP_VERSION = '3.1'
+
+    /**
+     * The application User-Agent, e.g. "bie-index/3.3.0".
+     *
+     * @return The User-Agent string, derived from info.app.name / info.app.version
+     */
+    static String userAgent() {
+        def config = Holders.grailsApplication?.config
+        String name = config?.getProperty('info.app.name', String, DEFAULT_APP_NAME) ?: DEFAULT_APP_NAME
+        String version = config?.getProperty('info.app.version', String, DEFAULT_APP_VERSION) ?: DEFAULT_APP_VERSION
+        return "${name}/${version}" as String
+    }
+
+    /**
+     * A request header map containing the application User-Agent.
+     * <p>
+     * Suitable for use as the {@code requestProperties} of Groovy's
+     * {@code URL.getText(Map, String)} / {@code JsonSlurper.parse(URL, Map)} and
+     * for ala-ws {@code WebService} calls.
+     *
+     * @return A map of ["User-Agent": userAgent()]
+     */
+    static Map<String, String> userAgentHeader() {
+        return ['User-Agent': userAgent()]
+    }
+
+    /**
+     * Connection configuration parameters carrying the application User-Agent,
+     * for Groovy's {@code URL.getText(Map, String)} / {@code URL.getText(Map)} and
+     * {@code JsonSlurper.parse(URL, Map)}.
+     * <p>
+     * These methods expect request headers nested under a {@code requestProperties}
+     * key, so this cannot be a flat header map.
+     *
+     * @return A map of [requestProperties: ["User-Agent": userAgent()]]
+     */
+    static Map getConnectionParams() {
+        return [requestProperties: userAgentHeader()]
+    }
+
+    /**
+     * Set the application User-Agent on a URLConnection.
+     *
+     * @param connection The connection to configure
+     * @return The same connection, for chaining
+     */
+    static URLConnection withUserAgent(URLConnection connection) {
+        connection.setRequestProperty('User-Agent', userAgent())
+        return connection
+    }
+}

--- a/src/test/groovy/au/org/ala/bie/NameServiceSpec.groovy
+++ b/src/test/groovy/au/org/ala/bie/NameServiceSpec.groovy
@@ -110,4 +110,20 @@ class NameServiceSpec extends Specification implements ServiceUnitTest<NameServi
         then:
         result == null
     }
+
+    void "outbound GET requests send an application User-Agent (not the JVM default)"() {
+        given:
+        wireMockServer.stubFor(WireMock.get(urlPathEqualTo("/api/searchByClassification"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody('{"success": false}')))
+
+        when:
+        service.search("Anything", null, null, null, null, null, null)
+
+        then: 'the request carried our application/version User-Agent'
+        wireMockServer.verify(getRequestedFor(urlPathEqualTo("/api/searchByClassification"))
+                .withHeader("User-Agent", equalTo(au.org.ala.bie.util.WebUtils.userAgent())))
+    }
 }

--- a/src/test/groovy/au/org/ala/bie/util/WebUtilsSpec.groovy
+++ b/src/test/groovy/au/org/ala/bie/util/WebUtilsSpec.groovy
@@ -1,0 +1,43 @@
+package au.org.ala.bie.util
+
+import spock.lang.Specification
+
+class WebUtilsSpec extends Specification {
+
+    def 'userAgent falls back to defaults when no grailsApplication is available'() {
+        expect: 'the application/version format using the built-in defaults'
+        WebUtils.userAgent() == "${WebUtils.DEFAULT_APP_NAME}/${WebUtils.DEFAULT_APP_VERSION}"
+    }
+
+    def 'userAgent uses application/version format (never the JVM default)'() {
+        expect:
+        WebUtils.userAgent() ==~ /[^\/]+\/[^\/]+/
+        !WebUtils.userAgent().startsWith('Java/')
+    }
+
+    def 'userAgentHeader is a flat User-Agent header map'() {
+        expect:
+        WebUtils.userAgentHeader() == ['User-Agent': WebUtils.userAgent()]
+    }
+
+    def 'connectionParams nests the User-Agent under requestProperties'() {
+        when:
+        def params = WebUtils.getConnectionParams()
+
+        then: 'suitable for URL.getText(Map, String) / JsonSlurper.parse(URL, Map)'
+        params == [requestProperties: ['User-Agent': WebUtils.userAgent()]]
+    }
+
+    def 'withUserAgent sets the User-Agent request property on a connection'() {
+        given:
+        def props = [:]
+        def connection = [setRequestProperty: { String k, String v -> props[k] = v }] as URLConnection
+
+        when:
+        def result = WebUtils.withUserAgent(connection)
+
+        then:
+        props['User-Agent'] == WebUtils.userAgent()
+        result.is(connection)
+    }
+}


### PR DESCRIPTION
**[update from Simon]**
FYI you may be able to do with without a code change - add the http.agent Java system property like so: https://github.com/AtlasOfLivingAustralia/ala-install/blob/master/ansible/roles/exec-jar/templates/service.conf#L6
it should get any UrlConnection and many Apache HTTP client based calls.

----

Requests from bie to bie-ws and biocache-ws have been coming up with the default `Java/11.0.31` which makes traffic analysis and WAF rules more difficult. Bots should always identify themselves. This is a vibe coded branch to address this. 

The agent found there were many other services making requests with the default Java UA, it was guided to come up with a DRY solution for all services and has created a WebUtils class that all services have been changed to use when making requests

agent output below:

# Implementation: Explicit User-Agent on outbound HTTP calls

**Mode**: default | **Date**: 2026-07-01 | **Status**: Complete (tests written, not executed — no JVM on this machine)

## 1. Changes (14 files, +1 new util, +1 new spec)

**Created**:
- `src/main/groovy/au/org/ala/bie/util/WebUtils.groovy` — central User-Agent helper. `userAgent()` → `"${info.app.name}/${info.app.version}"` (e.g. `bie-index/3.3.0-SNAPSHOT`) with defaults `bie-index/3.1` when config is unavailable. Also exposes `userAgentHeader()` (flat map for ala-ws `WebService`), `connectionParams` (`[requestProperties: [...]]` for Groovy `URL.getText`/`JsonSlurper.parse`), and `withUserAgent(URLConnection)`. Reads config via `grails.util.Holders` so it works from static util classes.
- `src/test/groovy/au/org/ala/bie/util/WebUtilsSpec.groovy` — unit tests for format, defaults, header shape, connection-param nesting, and `withUserAgent`.

**Modified** — applied UA at every outbound HTTP site across the three idioms found:
- `openConnection`/`openStream` (+`setRequestProperty` or `WebUtils.withUserAgent`): `BiocacheService.counts`, `NameService.searchByIds`, `CollectoryService.getBatch`, `DownloadService`, `BieAuthService`, `LayerService.getRegions`, `ImportService.getStringForUrl(URL)`.
- `getText`/`JsonSlurper.parse(URL)` (+`WebUtils.connectionParams`): `BiocacheService.search`, `NameService.search`, `CollectoryService.resources`+`get`, `BiocollectService.resources`, `LayerService.layers`+`get`, `ImportService.getConfigFile` (remote branch only), `ConservationListsSource` (remote branch only).
- Jsoup (+`.userAgent(...)`): `WordpressService` (×2), `KnowledgeBaseService` (×3).
- `ListService` refactored to delegate to `WebUtils`, removing its duplicated `info.app.*` lookup (the original reference implementation).
- `NameServiceSpec` — added a WireMock test asserting outbound GET carries the app User-Agent.

## 2. Quality (Tests written | Not executed | Docs: inline)
**Tests**: `WebUtilsSpec` (5 cases) + 1 added `NameServiceSpec` case. **Not run** — no JVM available locally; must be executed in CI / a Java environment before merge.
**Manual verification**: grep sweep confirms no outbound `getText`/`openConnection`/`openStream`/`Jsoup.connect` site remains without a User-Agent, except genuine classpath/local-file reads (`SpeciesGroupService` resource load, `ImportService` bundled `taxonRanks`/`identifierStatus` JSON) which are intentionally untouched.
**API signatures verified against Groovy docs**: `getText(URL,Map,String)`, `JsonSlurper.parse(URL,Map)`, `requestProperties` map key, static-getter property access.

## 3. Decisions
**Central helper in new `WebUtils`** (not extending `Encoder`): keeps URL-encoding and HTTP concerns separate; `Encoder` is purely about escaping. | Alt considered: per-service inline (rejected — duplication).
**Three-shaped API** (`userAgent()` string, `userAgentHeader()` flat map, `connectionParams` nested map): the codebase has three outbound idioms and Groovy's `getText`/`parse` require headers nested under `requestProperties`, whereas ala-ws `WebService` and `setRequestProperty` want a flat value. One shape can't serve all three.
**Config via `Holders`**: lets the static helper read `info.app.*` without threading `grailsApplication` through util classes (`ConservationListsSource` is a plain POGO).
**`getStringForUrl`/`getRegions` switched `openStream()`→`openConnection().getInputStream()`**: `openStream()` cannot set request headers; the connection form is equivalent and lets us set the UA.

## 4. Handoff
**Run**: `./gradlew test` in a Java 11 environment to execute the new specs, then `/epcc-commit`.
**Blockers**: None functional. Tests are unexecuted pending a JVM.
**TODOs / follow-ups**:
- Larger refactor to a shared HTTP client / ala-ws `WebService` across all services remains out of scope (noted in EPCC_EXPLORE as tech debt).
- Consider adding UA assertions to `BiocacheService`/`CollectoryService` specs too (currently only `NameServiceSpec` asserts the header).

---

## Context Used
**Planning**: EPCC_PLAN.md — central helper, `info.app.*` value, all external calls (all three confirmed with user).
**Exploration**: EPCC_EXPLORE.md — outbound HTTP is hand-rolled per service; `ListService` was the reference pattern generalized here. Note: the exploration/plan grep missed `LayerService`, caught during implementation verification and included.